### PR TITLE
Fix PNPM lock scanner

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
         "illuminate/console": "^10.0|^11.0|^12.0",
         "illuminate/contracts": "^10.0|^11.0|^12.0",
         "illuminate/routing": "^10.0|^11.0|^12.0",
-        "illuminate/support": "^10.0|^11.0|^12.0"
+        "illuminate/support": "^10.0|^11.0|^12.0",
+        "symfony/yaml": "^7.3"
     },
     "require-dev": {
         "laravel/pint": "^1.14",


### PR DESCRIPTION
This PR adds `symfony/yaml` to dependencies. The package uses `symfony/yaml`, but it's only a dev dependency of a dev dependency right now, so this doesn't work in production. That's why tests pass.