### PR TITLE
Add prettier and eslint to detectable packages

### DIFF
--- a/src/Enums/Packages.php
+++ b/src/Enums/Packages.php
@@ -38,9 +38,11 @@ enum Packages: string
     // NPM
     case ALPINEJS = 'alpinejs';
     case ECHO = 'laravel-echo';
+    case ESLINT = 'eslint';
     case INERTIA_REACT = 'inertia-react';
     case INERTIA_SVELTE = 'inertia-svelte';
     case INERTIA_VUE = 'inertia-vue';
+    case PRETTIER = 'prettier';
     case REACT = 'react';
     case TAILWINDCSS = 'tailwindcss';
     case VUE = 'vue';

--- a/src/Scanners/BasePackageScanner.php
+++ b/src/Scanners/BasePackageScanner.php
@@ -18,11 +18,13 @@ abstract class BasePackageScanner
      */
     protected array $map = [
         'alpinejs' => Packages::ALPINEJS,
+        'eslint' => Packages::ESLINT,
         '@inertiajs/react' => [Packages::INERTIA, Packages::INERTIA_REACT],
         '@inertiajs/svelte' => [Packages::INERTIA, Packages::INERTIA_SVELTE],
         '@inertiajs/vue3' => [Packages::INERTIA, Packages::INERTIA_VUE],
         'laravel-echo' => Packages::ECHO,
         '@laravel/vite-plugin-wayfinder' => [Packages::WAYFINDER, Packages::WAYFINDER_VITE],
+        'prettier' => Packages::PRETTIER,
         'react' => Packages::REACT,
         'tailwindcss' => [Packages::TAILWINDCSS],
         'vue' => Packages::VUE,


### PR DESCRIPTION
These packages are used in the starter kits, and adding them will help ensure the code is linted correctly when using boost (if this is merged I can open a PR to add the guidelines files in boost)