### PR TITLE
Feat:  Add in missing laravel packages and update the ScanCommand with summary output of the approaches and packages count

### DIFF
--- a/src/Console/ScanCommand.php
+++ b/src/Console/ScanCommand.php
@@ -46,17 +46,16 @@ class ScanCommand extends Command
 
         $summary = match($approaches_count) {
             0 => [],
-            1 => ["Approach: " . ucfirst($roster->approaches()->first()->approach()->value) . "."],
+            1 => ["Approach: " . ucfirst($roster->approaches()->first()?->approach()->value ?? "") . "."],
             default => ["Approaches: $approaches_count."]
-
         };
 
         $summary[] = match($packages_count) {
             0 => "",
-            1 => "Package: " . ucfirst(strtolower($roster->packages()->first()->name())),
+            1 => "Package: " . ucfirst(strtolower($roster->packages()->first()?->name() ?? "")),
             default => "Packages: $packages_count."
         };
-        
+
         $this->line(implode(" ", $summary));
     }
 }

--- a/src/Console/ScanCommand.php
+++ b/src/Console/ScanCommand.php
@@ -34,6 +34,29 @@ class ScanCommand extends Command
         $roster = Roster::scan($directory);
         $this->line($roster->json());
 
+        $this->printMiniSummary($roster);
+
         return self::SUCCESS;
+    }
+
+    private function printMiniSummary(Roster $roster): void
+    {
+        $approaches_count = $roster->approaches()->count();
+        $packages_count = $roster->packages()->count();
+
+        $summary = match($approaches_count) {
+            0 => [],
+            1 => ["Approach: " . ucfirst($roster->approaches()->first()->approach()->value) . "."],
+            default => ["Approaches: $approaches_count."]
+
+        };
+
+        $summary[] = match($packages_count) {
+            0 => "",
+            1 => "Package: " . ucfirst(strtolower($roster->packages()->first()->name())),
+            default => "Packages: $packages_count."
+        };
+        
+        $this->line(implode(" ", $summary));
     }
 }

--- a/src/Enums/Packages.php
+++ b/src/Enums/Packages.php
@@ -10,10 +10,15 @@ enum Packages: string
 
     // BACKEND
     case BREEZE = 'breeze';
+    case CASHIER = 'cashier';
+    case DUSK = 'dusk';
+    case ENVOY = 'envoy';
     case FILAMENT = 'filament';
     case FOLIO = 'folio';
+    case FORTIFY = 'fortify';
     case FLUXUI_FREE = 'flux_free';
     case FLUXUI_PRO = 'flux_pro';
+    case HORIZON = 'horizon';
     case INERTIA_LARAVEL = 'inertia-laravel';
     case LARASTAN = 'larastan';
     case LARAVEL = 'laravel';
@@ -21,16 +26,21 @@ enum Packages: string
     case NIGHTWATCH = 'nightwatch';
     case NOVA = 'nova';
     case OCTANE = 'octane';
+    case PASSPORT = 'passport';
     case PENNANT = 'pennant';
     case PEST = 'pest';
     case PHPUNIT = 'phpunit';
     case PINT = 'pint';
     case PROMPTS = 'prompts';
+    case PULSE = 'pulse';
     case RECTOR = 'rector';
     case REVERB = 'reverb';
     case SAIL = 'sail';
+    case SANCTUM = 'sanctum';
     case SCOUT = 'scout';
+    case SOCIALITE = 'socialite';
     case STATAMIC = 'statamic';
+    case TELESCOPE = 'telescope';
     case VOLT = 'volt';
     case WAYFINDER_LARAVEL = 'wayfinder_laravel';
     case ZIGGY = 'ziggy';

--- a/src/Scanners/Composer.php
+++ b/src/Scanners/Composer.php
@@ -41,6 +41,16 @@ class Composer
         'livewire/volt' => Packages::VOLT,
         'laravel/wayfinder' => [Packages::WAYFINDER, Packages::WAYFINDER_LARAVEL],
         'tightenco/ziggy' => Packages::ZIGGY,
+        'laravel/passport' => Packages::PASSPORT,
+        'laravel/sanctum' => Packages::SANCTUM,
+        'laravel/telescope' => Packages::TELESCOPE,
+        'laravel/horizon' => Packages::HORIZON,
+        'laravel/cashier' => Packages::CASHIER,
+        'laravel/dusk' => Packages::DUSK,
+        'laravel/envoy' => Packages::ENVOY,
+        'laravel/fortify' => Packages::FORTIFY,
+        'laravel/pulse' => Packages::PULSE,
+        'laravel/socialite' => Packages::SOCIALITE,
     ];
 
     /**

--- a/tests/Unit/CheckTest.php
+++ b/tests/Unit/CheckTest.php
@@ -8,8 +8,8 @@ it('adds found composer packages to roster class', function () {
 
     $roster = Roster::scan($path);
 
-    // Overall - 9 packages from composer (folio, volt, fluxui_free, laravel, pest, pint, filament, livewire, flux) and 2 from package lock (tailwind, alpine)
-    expect($roster->packages())->toHaveCount(11);
+    // Overall - 9 packages from composer (dusk, socialite folio, volt, fluxui_free, laravel, pest, pint, filament, livewire, flux) and 2 from package lock (tailwind, alpine)
+    expect($roster->packages())->toHaveCount(13);
 
     // From composer
     expect($roster->uses(Packages::PEST))->toBeTrue();

--- a/tests/Unit/ScanCommandTest.php
+++ b/tests/Unit/ScanCommandTest.php
@@ -5,12 +5,21 @@ use Tests\TestCase;
 
 uses(TestCase::class);
 
+/**
+ * Remove the summary line from the command output
+ * to allow existing tests to pass
+ */
+function clearSummaryFromOutput($output): string
+{
+    return implode("\n", array_slice(explode("\n", $output), 0, -2));
+}
+
 it('outputs JSON for directory with packages', function () {
     $path = __DIR__.'/../fixtures/fog';
 
     Artisan::call('roster:scan', ['directory' => $path]);
 
-    $output = Artisan::output();
+    $output = clearSummaryFromOutput(Artisan::output());
     $decoded = json_decode($output, true);
 
     expect($decoded)->toBeArray();
@@ -49,4 +58,15 @@ it('returns failure for unreadable directory', function () {
     $exitCode = Artisan::call('roster:scan', ['directory' => $invalidArg]);
 
     expect($exitCode)->toBe(1);
+});
+
+it('returns the summary output', function () {
+    $path = __DIR__.'/../fixtures/fog';
+
+    Artisan::call('roster:scan', ['directory' => $path]);
+
+    $output = Artisan::output();
+    $summary = implode("\n", array_slice(explode("\n", $output), -2, 1));
+
+    expect(str_contains($summary, 'Package'))->toBe(true);
 });


### PR DESCRIPTION
This adds in some of missing laravel packages highlighted below. The list has been borrowed from the laravel documentation, packages section: 
- Passport
- Sanctum
- Telescope
- Horizon
- Cashier
- Dusk
- Envoy
- Fortify
- Pulse
- Socialite