### PR TITLE
Docs: Add missing import to usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ $roster = Roster::scan($directory);
 
 **Query the roster**
 ```php
+use Laravel\Roster\Packages;
+
 // Get all packages
 $roster->packages();
 


### PR DESCRIPTION
## Description
This PR fixes a small issue in the Laravel Roster documentation.  
The usage example included `Packages::INERTIA` but did not show the corresponding  
`use Laravel\Roster\Packages;` import. This could cause confusion for new users.

## Changes Made
- Added `use Laravel\Roster\Packages;` in the **Query the roster** example.

## Why This Is Needed
- Prevents confusion when using constants like `Packages::INERTIA`.
- Keeps the documentation examples complete and accurate.

## Checklist
- [x] Documentation updated  
- [x] No breaking changes introduced
