### PR TITLE
feat: add PHPUnit package detection support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /vendor
 composer.lock
 !tests/fixtures/fog/composer.lock
+!tests/fixtures/phpunit/composer.lock
 /phpunit.xml
 .phpunit.result.cache
 .claude

--- a/src/Scanners/Composer.php
+++ b/src/Scanners/Composer.php
@@ -48,6 +48,7 @@ class Composer
         'livewire/livewire' => Packages::LIVEWIRE,
         'livewire/volt' => Packages::VOLT,
         'pestphp/pest' => Packages::PEST,
+        'phpunit/phpunit' => Packages::PHPUNIT,
         'rector/rector' => Packages::RECTOR,
         'statamic/cms' => Packages::STATAMIC,
         'tightenco/ziggy' => Packages::ZIGGY,

--- a/tests/Unit/CheckTest.php
+++ b/tests/Unit/CheckTest.php
@@ -8,8 +8,8 @@ it('adds found composer packages to roster class', function () {
 
     $roster = Roster::scan($path);
 
-    // Overall - 9 packages from composer (dusk, socialite folio, volt, fluxui_free, laravel, pest, pint, filament, livewire, flux) and 2 from package lock (tailwind, alpine)
-    expect($roster->packages())->toHaveCount(13);
+    // Overall - 12 packages from composer (dusk, socialite, folio, volt, fluxui_free, laravel, pest, pint, filament, livewire, flux, phpunit) and 2 from package lock (tailwind, alpine)
+    expect($roster->packages())->toHaveCount(14);
 
     // From composer
     expect($roster->uses(Packages::PEST))->toBeTrue();

--- a/tests/Unit/Scanners/ComposerTest.php
+++ b/tests/Unit/Scanners/ComposerTest.php
@@ -54,3 +54,13 @@ it('adds 2 entries for inertia', function () {
     expect($inertia->version())->toEqual('123.456.789');
     expect($inertia->isDev())->toBeFalse();
 });
+
+it('detects PHPUnit from fixture', function () {
+    $path = __DIR__.'/../../fixtures/phpunit/composer.lock';
+    $uses = (new Composer($path))->scan();
+
+    $phpunit = $uses->first(fn ($item) => $item->package() === Packages::PHPUNIT);
+    expect($phpunit)->not()->toBeNull();
+    expect($phpunit->version())->toEqual('11.4.3');
+    expect($phpunit->isDev())->toBeTrue();
+});

--- a/tests/fixtures/phpunit/composer.lock
+++ b/tests/fixtures/phpunit/composer.lock
@@ -1,0 +1,64 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "test-phpunit-fixture",
+    "packages": [],
+    "packages-dev": [
+        {
+            "name": "phpunit/phpunit",
+            "version": "v11.4.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit.git",
+                "reference": "test"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/test",
+                "reference": "test",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "The PHP Unit Testing framework.",
+            "homepage": "https://phpunit.de/",
+            "keywords": [
+                "phpunit",
+                "testing",
+                "xunit"
+            ],
+            "time": "2024-10-28T13:07:50+00:00"
+        }
+    ],
+    "packages-plugin": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": {},
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "php": ">=8.2"
+    },
+    "platform-dev": [],
+    "plugin-api-version": "2.6.0"
+}


### PR DESCRIPTION
Adds `phpunit/phpunit` to Composer scanner package mapping to enable detection of PHPUnit installations.

  ## Changes
  - Added PHPUnit package mapping to Composer scanner
  - Added test fixture for PHPUnit detection
  - Added test case to verify detection works
  - Updated existing test to account for PHPUnit in fog fixture

  Fixes #18