### PR TITLE
Detect package direct or indirect

### DIFF
--- a/src/Package.php
+++ b/src/Package.php
@@ -6,7 +6,32 @@ use Laravel\Roster\Enums\Packages;
 
 class Package
 {
+    protected bool $direct = false;
+
+    protected string $constraint = '';
+
     public function __construct(protected Packages $package, protected string $packageName, protected string $version, protected bool $dev = false) {}
+
+    public function setDev(bool $dev = true): self
+    {
+        $this->dev = $dev;
+
+        return $this;
+    }
+
+    public function setDirect(bool $direct = true): self
+    {
+        $this->direct = $direct;
+
+        return $this;
+    }
+
+    public function setConstraint(string $constraint = ''): self
+    {
+        $this->constraint = $constraint;
+
+        return $this;
+    }
 
     public function name(): string
     {
@@ -21,6 +46,16 @@ class Package
     public function version(): string
     {
         return $this->version;
+    }
+
+    public function direct(): bool
+    {
+        return $this->direct;
+    }
+
+    public function constraint(): string
+    {
+        return $this->constraint;
     }
 
     public function majorVersion(): string

--- a/src/Package.php
+++ b/src/Package.php
@@ -53,6 +53,11 @@ class Package
         return $this->direct;
     }
 
+    public function indirect(): bool
+    {
+        return ! $this->direct;
+    }
+
     public function constraint(): string
     {
         return $this->constraint;

--- a/src/Scanners/Composer.php
+++ b/src/Scanners/Composer.php
@@ -55,6 +55,9 @@ class Composer
         'tightenco/ziggy' => Packages::ZIGGY,
     ];
 
+    /** @var array<string, array{constraint: string, isDev: bool}> */
+    protected array $directPackages = [];
+
     /**
      * @param  string  $path  - composer.lock
      */
@@ -99,6 +102,7 @@ class Composer
             return $mappedItems;
         }
 
+        $this->directPackages = $this->direct();
         $packages = $json['packages'] ?? [];
         $devPackages = $json['packages-dev'] ?? [];
 
@@ -109,17 +113,60 @@ class Composer
     }
 
     /**
+     * Returns direct dependencies as defined in composer.json
+     *
+     * @return array<string, array{constraint: string, isDev: bool}>
+     * */
+    protected function direct(): array
+    {
+        $packages = [];
+        $filename = realpath(dirname($this->path)).DIRECTORY_SEPARATOR.'composer.json';
+        if (file_exists($filename) === false || is_readable($filename) === false) {
+            return $packages;
+        }
+
+        $json = file_get_contents($filename);
+        if ($json === false) {
+            return $packages;
+        }
+
+        $json = json_decode($json, true);
+        if (json_last_error() !== JSON_ERROR_NONE || ! is_array($json)) {
+            return $packages;
+        }
+
+        foreach (($json['require'] ?? []) as $name => $constraint) {
+            $packages[$name] = [
+                'constraint' => $constraint,
+                'isDev' => false,
+            ];
+        }
+
+        foreach (($json['require-dev'] ?? []) as $name => $constraint) {
+            $packages[$name] = [
+                'constraint' => $constraint,
+                'isDev' => true,
+            ];
+        }
+
+        return $packages;
+    }
+
+    /**
      * Process packages and add them to the mapped items collection
      *
      * @param  array<int, array<string, string>>  $packages
      * @param  Collection<int, Package|Approach>  $mappedItems
+     * @return Collection<int, Package|Approach>
      */
-    private function processPackages(array $packages, Collection $mappedItems, bool $isDev): void
+    private function processPackages(array $packages, Collection $mappedItems, bool $isDev): Collection
     {
         foreach ($packages as $package) {
             $packageName = $package['name'] ?? '';
             $version = $package['version'] ?? '';
             $mappedPackage = $this->map[$packageName] ?? null;
+            $direct = false;
+            $constraint = $version;
 
             if (is_null($mappedPackage)) {
                 continue;
@@ -129,14 +176,21 @@ class Composer
                 $mappedPackage = [$mappedPackage];
             }
 
+            if (array_key_exists($packageName, $this->directPackages) === true) {
+                $direct = true;
+                $constraint = $this->directPackages[$packageName]['constraint'];
+            }
+
             foreach ($mappedPackage as $mapped) {
                 $niceVersion = preg_replace('/[^0-9.]/', '', $version) ?? '';
                 $mappedItems->push(match (get_class($mapped)) {
-                    Packages::class => new Package($mapped, $packageName, $niceVersion, $isDev),
+                    Packages::class => (new Package($mapped, $packageName, $niceVersion, $isDev))->setDirect($direct)->setConstraint($constraint),
                     Approaches::class => new Approach($mapped),
                     default => throw new \InvalidArgumentException('Unsupported mapping')
                 });
             }
         }
+
+        return $mappedItems;
     }
 }

--- a/tests/Unit/Scanners/ComposerTest.php
+++ b/tests/Unit/Scanners/ComposerTest.php
@@ -10,6 +10,8 @@ it('can parse installed packages', function () {
     $laravel = $uses->first(fn ($item) => $item->package() === Packages::LARAVEL);
     expect($laravel->version())->toEqual('11.44.2');
     expect($laravel->isDev())->toBeFalse();
+    expect($laravel->direct())->toBeTrue();
+    expect($laravel->constraint())->toEqual('^11.0');
 
     $pest = $uses->first(fn ($item) => $item->package() === Packages::PEST);
     expect($pest->version())->toEqual('3.8.1');

--- a/tests/fixtures/fog/composer.json
+++ b/tests/fixtures/fog/composer.json
@@ -1,0 +1,124 @@
+{
+    "name": "laravel/laravel",
+    "description": "The Laravel Framework.",
+    "keywords": ["framework", "laravel"],
+    "license": "MIT",
+    "type": "project",
+    "repositories": [
+        {
+            "type": "path",
+            "url": "../boost"
+        },
+        {
+            "type": "git",
+            "url": "git@github.com:laravel/mcp.git"
+        }
+    ],
+    "require": {
+        "php": "^8.3",
+        "ext-exif": "*",
+        "ext-fileinfo": "*",
+        "ext-gd": "*",
+        "ext-imagick": "*",
+        "codeat3/blade-phosphor-icons": "^2.0",
+        "devdojo/app": "0.11.0",
+        "devdojo/auth": "^1.0",
+        "devdojo/themes": "0.0.11",
+        "filament/filament": "^3.2",
+        "gehrisandro/tailwind-merge-laravel": "^1.2",
+        "guzzlehttp/guzzle": "^7.2",
+        "hidehalo/nanoid-php": "^2.0",
+        "inertiajs/inertia-laravel": "^2.0",
+        "intervention/image": "^2.7",
+        "lab404/laravel-impersonate": "^1.7.5",
+        "laravel/folio": "^1.1",
+        "laravel/framework": "^11.0",
+        "laravel/pint": "^1.20",
+        "laravel/tinker": "^2.7",
+        "laravel/ui": "^4.5",
+        "livewire/flux": "^2.1",
+        "livewire/livewire": "^3.0",
+        "ralphjsmit/livewire-urls": "^1.4",
+        "spatie/browsershot": "^5.0",
+        "spatie/crawler": "^8.4",
+        "spatie/image": "^3.8",
+        "spatie/laravel-flare": "^1.1",
+        "spatie/laravel-honeypot": "^4.5",
+        "spatie/laravel-mailcoach-mailer": "^1.5",
+        "spatie/laravel-permission": "^6.4",
+        "spatie/laravel-slack-alerts": "^1.5",
+        "stripe/stripe-php": "^15.3",
+        "tempest/highlight": "^2.11",
+        "tymon/jwt-auth": "@dev"
+    },
+    "require-dev": {
+        "alebatistella/duskapiconf": "^1.2",
+        "ashleyhindle/croft": "dev-main",
+        "barryvdh/laravel-debugbar": "^3.14",
+        "fakerphp/faker": "^1.9.1",
+        "laravel/boost": "1.x-dev",
+        "laravel/dusk": "^8.0",
+        "mockery/mockery": "^1.4.4",
+        "nunomaduro/collision": "6.4.0|^7.0|^8.1",
+        "pestphp/pest": "^3.4",
+        "pestphp/pest-plugin-laravel": "^3.0",
+        "phpunit/phpunit": "^11.0",
+        "soloterm/solo": "^0.3.1",
+        "spatie/laravel-ignition": "^2.9"
+    },
+    "autoload": {
+        "psr-4": {
+            "App\\": "app/",
+            "Database\\Factories\\": "database/factories/",
+            "Database\\Seeders\\": "database/seeders/",
+            "Wave\\": "wave/src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Tests\\": "tests/"
+        }
+    },
+    "extra": {
+        "laravel": {
+            "dont-discover": [],
+            "providers": [
+                "Wave\\WaveServiceProvider"
+            ]
+        }
+    },
+    "scripts": {
+        "test": [
+            "vendor/bin/pest"
+        ],
+        "post-root-package-install": [
+            "@php -r \"file_exists('.env') || copy('.env.example', '.env');\""
+        ],
+        "post-create-project-cmd": [
+            "@php artisan key:generate"
+        ],
+        "post-autoload-dump": [
+            "Illuminate\\Foundation\\ComposerScripts::postAutoloadDump",
+            "@php artisan package:discover",
+            "@php artisan storage:link",
+            "@php artisan filament:upgrade"
+        ],
+        "post-update-cmd": [
+            "@php artisan vendor:publish --tag=livewire:assets --ansi --force"
+        ],
+        "dev": [
+            "Composer\\Config::disableProcessTimeout",
+            "npx concurrently -c \"#93c5fd,#c4b5fd,#fb7185,#fdba74\" \"php artisan queue:listen --tries=1\" \"npm run dev\" \"npm run dev:og\" --names=queue,vite,vite-og"
+        ]
+    },
+    "config": {
+        "preferred-install": "dist",
+        "sort-packages": true,
+        "optimize-autoloader": true,
+        "allow-plugins": {
+            "pestphp/pest-plugin": true
+        }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
+}


### PR DESCRIPTION
# What & Why
Adds detection of whether a composer package is a direct or indirect dependency, and its constraint.

This will allow consumers to add logic based on whether the detected package was explicitly requested or not.

# How I tested
  1. Ran the tests
  2. Ran `artisan roster:scan . ` on projects using this