### PR TITLE
Add --dev option to Composer command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Laravel Roster detects which Laravel ecosystem packages are in use within a proj
 To get started, install Roster via Composer:
 
 ```bash
-composer require laravel/roster
+composer require laravel/roster --dev
 ```
 
 ## Usage


### PR DESCRIPTION
Since the package is tagged as "dev", Composer recommends that it be placed in the `require-dev` section of the composer.json file.

I know it's minor, but I think this slight change to the README will help users of this package avoid being prompted by Composer to re-run the command with `--dev`.
