### PR TITLE
refactor: extract dup logic into abstract class

### DIFF
--- a/src/Scanners/BasePackageScanner.php
+++ b/src/Scanners/BasePackageScanner.php
@@ -35,7 +35,7 @@ abstract class BasePackageScanner
     /**
      * Returns the expected lock file name
      */
-    abstract public function lockFile(): string;
+    abstract protected function lockFile(): string;
 
     /**
      * @return \Illuminate\Support\Collection<int, \Laravel\Roster\Package|\Laravel\Roster\Approach>

--- a/src/Scanners/BunPackageLock.php
+++ b/src/Scanners/BunPackageLock.php
@@ -7,7 +7,7 @@ use Illuminate\Support\Facades\Log;
 
 class BunPackageLock extends BasePackageScanner
 {
-    public function lockFile(): string
+    protected function lockFile(): string
     {
         return 'bun.lock';
     }

--- a/src/Scanners/NpmPackageLock.php
+++ b/src/Scanners/NpmPackageLock.php
@@ -7,7 +7,7 @@ use Illuminate\Support\Facades\Log;
 
 class NpmPackageLock extends BasePackageScanner
 {
-    public function lockFile(): string
+    protected function lockFile(): string
     {
         return 'package-lock.json';
     }

--- a/src/Scanners/PnpmPackageLock.php
+++ b/src/Scanners/PnpmPackageLock.php
@@ -8,7 +8,7 @@ use Symfony\Component\Yaml\Yaml;
 
 class PnpmPackageLock extends BasePackageScanner
 {
-    public function lockFile(): string
+    protected function lockFile(): string
     {
         return 'pnpm-lock.yaml';
     }

--- a/src/Scanners/YarnPackageLock.php
+++ b/src/Scanners/YarnPackageLock.php
@@ -16,7 +16,7 @@ class YarnPackageLock extends BasePackageScanner
 
     private const YARN_V4_VERSION = '/^version:\s+(.+)$/';
 
-    public function lockFile(): string
+    protected function lockFile(): string
     {
         return 'yarn.lock';
     }


### PR DESCRIPTION
When reading the source code I noticed a bit of duplication. 

This PR basically extracts the common logic into the abstract class so it simplifies it a little ( I hope! )

This mainly changes :
-  The `canScan` method - as was the same for each scanner.
-   lockpath file path logic - as it was repeated 


Thought I'd do a simple PR for now! open to feedback 🫡  