### PR TITLE
Add path detection functionality

### DIFF
--- a/src/Enums/PackageSource.php
+++ b/src/Enums/PackageSource.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Laravel\Roster\Enums;
+
+enum PackageSource: string
+{
+    case COMPOSER = 'composer';
+    case NPM = 'npm';
+}

--- a/src/Enums/Packages.php
+++ b/src/Enums/Packages.php
@@ -4,11 +4,8 @@ namespace Laravel\Roster\Enums;
 
 enum Packages: string
 {
-    // Compound
-    case INERTIA = 'inertia';
-    case WAYFINDER = 'wayfinder';
-
     // BACKEND
+    case AI = 'ai';
     case BOOST = 'boost';
     case BREEZE = 'breeze';
     case CASHIER = 'cashier';

--- a/src/Enums/Packages.php
+++ b/src/Enums/Packages.php
@@ -42,7 +42,7 @@ enum Packages: string
     case STATAMIC = 'statamic';
     case TELESCOPE = 'telescope';
     case VOLT = 'volt';
-    case WAYFINDER_LARAVEL = 'wayfinder_laravel';
+    case WAYFINDER = 'wayfinder';
     case ZIGGY = 'ziggy';
 
     // NPM

--- a/src/Package.php
+++ b/src/Package.php
@@ -13,8 +13,13 @@ class Package
 
     protected ?PackageSource $source = null;
 
-    public function __construct(protected Packages $package, protected string $packageName, protected string $version, protected bool $dev = false, protected ?string $path = null)
-    {
+    public function __construct(
+        protected Packages $package,
+        protected string $packageName,
+        protected string $version,
+        protected bool $dev = false,
+        protected ?string $path = null
+    ) {
         //
     }
 

--- a/src/Package.php
+++ b/src/Package.php
@@ -3,6 +3,7 @@
 namespace Laravel\Roster;
 
 use Laravel\Roster\Enums\Packages;
+use Laravel\Roster\Enums\PackageSource;
 
 class Package
 {
@@ -10,7 +11,12 @@ class Package
 
     protected string $constraint = '';
 
-    public function __construct(protected Packages $package, protected string $packageName, protected string $version, protected bool $dev = false) {}
+    protected ?PackageSource $source = null;
+
+    public function __construct(protected Packages $package, protected string $packageName, protected string $version, protected bool $dev = false,  protected ?string $path = null) 
+    {
+        //
+    }
 
     public function setDev(bool $dev = true): self
     {
@@ -29,6 +35,20 @@ class Package
     public function setConstraint(string $constraint = ''): self
     {
         $this->constraint = $constraint;
+
+        return $this;
+    }
+
+    public function setSource(PackageSource $source): self
+    {
+        $this->source = $source;
+
+        return $this;
+    }
+
+    public function setPath(string $path): self
+    {
+        $this->path = $path;
 
         return $this;
     }
@@ -71,6 +91,16 @@ class Package
     public function isDev(): bool
     {
         return $this->dev;
+    }
+
+    public function source(): ?PackageSource
+    {
+        return $this->source;
+    }
+
+    public function path(): ?string
+    {
+        return $this->path;
     }
 
     public function rawName(): string

--- a/src/Package.php
+++ b/src/Package.php
@@ -13,7 +13,7 @@ class Package
 
     protected ?PackageSource $source = null;
 
-    public function __construct(protected Packages $package, protected string $packageName, protected string $version, protected bool $dev = false,  protected ?string $path = null) 
+    public function __construct(protected Packages $package, protected string $packageName, protected string $version, protected bool $dev = false, protected ?string $path = null)
     {
         //
     }

--- a/src/Roster.php
+++ b/src/Roster.php
@@ -133,6 +133,8 @@ class Roster
             'packages' => $this->packages->map(fn (Package $package) => [
                 'name' => $package->name(),
                 'version' => $package->version(),
+                'source' => $package->source()?->value,
+                'path' => $package->path(),
             ])->toArray(),
             'nodePackageManager' => $this->nodePackageManager?->value,
         ], JSON_PRETTY_PRINT) ?: '{}';

--- a/src/Scanners/BasePackageScanner.php
+++ b/src/Scanners/BasePackageScanner.php
@@ -149,7 +149,9 @@ abstract class BasePackageScanner
 
     protected function computePath(string $packageName): string
     {
-        return $this->path.'node_modules'.DIRECTORY_SEPARATOR
+        $basePath = realpath($this->path) ?: $this->path;
+
+        return $basePath.DIRECTORY_SEPARATOR.'node_modules'.DIRECTORY_SEPARATOR
             .str_replace('/', DIRECTORY_SEPARATOR, $packageName);
     }
 

--- a/src/Scanners/BasePackageScanner.php
+++ b/src/Scanners/BasePackageScanner.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Facades\Log;
 use Laravel\Roster\Approach;
 use Laravel\Roster\Enums\Approaches;
 use Laravel\Roster\Enums\Packages;
+use Laravel\Roster\Enums\PackageSource;
 use Laravel\Roster\Package;
 
 abstract class BasePackageScanner
@@ -14,16 +15,16 @@ abstract class BasePackageScanner
     /**
      * Map of package names to enums
      *
-     * @var array<string, Packages|Approaches|array<int, Packages|Approaches>>
+     * @var array<string, Packages|Approaches>
      */
     protected array $map = [
         'alpinejs' => Packages::ALPINEJS,
         'eslint' => Packages::ESLINT,
-        '@inertiajs/react' => [Packages::INERTIA, Packages::INERTIA_REACT],
-        '@inertiajs/svelte' => [Packages::INERTIA, Packages::INERTIA_SVELTE],
-        '@inertiajs/vue3' => [Packages::INERTIA, Packages::INERTIA_VUE],
+        '@inertiajs/react' => Packages::INERTIA_REACT,
+        '@inertiajs/svelte' => Packages::INERTIA_SVELTE,
+        '@inertiajs/vue3' => Packages::INERTIA_VUE,
         'laravel-echo' => Packages::ECHO,
-        '@laravel/vite-plugin-wayfinder' => [Packages::WAYFINDER, Packages::WAYFINDER_VITE],
+        '@laravel/vite-plugin-wayfinder' => Packages::WAYFINDER_VITE,
         'prettier' => Packages::PRETTIER,
         'react' => Packages::REACT,
         'tailwindcss' => Packages::TAILWINDCSS,
@@ -78,10 +79,6 @@ abstract class BasePackageScanner
                 continue;
             }
 
-            if (! is_array($mappedPackage)) {
-                $mappedPackage = [$mappedPackage];
-            }
-
             if (! is_null($versionCb)) {
                 $version = $versionCb($packageName, $version);
             }
@@ -96,14 +93,12 @@ abstract class BasePackageScanner
                 $packageIsDev = $directPackages[$packageName]['isDev'];
             }
 
-            foreach ($mappedPackage as $mapped) {
-                $niceVersion = preg_replace('/[^0-9.]/', '', $version) ?? '';
-                $mappedItems->push(match (get_class($mapped)) {
-                    Packages::class => (new Package($mapped, $packageName, $niceVersion, $packageIsDev))->setDirect($direct)->setConstraint($constraint),
-                    Approaches::class => new Approach($mapped),
-                    default => throw new \InvalidArgumentException('Unsupported mapping')
-                });
-            }
+            $niceVersion = preg_replace('/[^0-9.]/', '', $version) ?? '';
+            $mappedItems->push(match (get_class($mappedPackage)) {
+                Packages::class => (new Package($mappedPackage, $packageName, $niceVersion, $packageIsDev))->setDirect($direct)->setConstraint($constraint)->setSource(PackageSource::NPM)->setPath($this->computePath($packageName)),
+                Approaches::class => new Approach($mappedPackage),
+                default => throw new \InvalidArgumentException('Unsupported mapping')
+            });
         }
     }
 
@@ -150,6 +145,12 @@ abstract class BasePackageScanner
         }
 
         return $this->directPackages;
+    }
+
+    protected function computePath(string $packageName): string
+    {
+        return $this->path.'node_modules'.DIRECTORY_SEPARATOR
+            .str_replace('/', DIRECTORY_SEPARATOR, $packageName);
     }
 
     /**

--- a/src/Scanners/Composer.php
+++ b/src/Scanners/Composer.php
@@ -49,7 +49,7 @@ class Composer
         'laravel/scout' => Packages::SCOUT,
         'laravel/socialite' => Packages::SOCIALITE,
         'laravel/telescope' => Packages::TELESCOPE,
-        'laravel/wayfinder' => Packages::WAYFINDER_LARAVEL,
+        'laravel/wayfinder' => Packages::WAYFINDER,
         'livewire/flux' => Packages::FLUXUI_FREE,
         'livewire/flux-pro' => Packages::FLUXUI_PRO,
         'livewire/livewire' => Packages::LIVEWIRE,

--- a/src/Scanners/Composer.php
+++ b/src/Scanners/Composer.php
@@ -12,6 +12,8 @@ use Laravel\Roster\Package;
 
 class Composer
 {
+    protected string $vendorDir = 'vendor';
+
     /**
      * Map of composer package names to enums
      *
@@ -139,6 +141,11 @@ class Composer
             return $packages;
         }
 
+        $config = $json['config'] ?? [];
+        if (is_array($config) && isset($config['vendor-dir']) && is_string($config['vendor-dir'])) {
+            $this->vendorDir = $config['vendor-dir'];
+        }
+
         foreach ((array) ($json['require'] ?? []) as $name => $constraint) {
             $packages[$name] = [
                 'constraint' => $constraint,
@@ -194,7 +201,8 @@ class Composer
 
     private function computePath(string $packageName): string
     {
-        return realpath(dirname($this->path)).DIRECTORY_SEPARATOR.'vendor'.DIRECTORY_SEPARATOR
+        return realpath(dirname($this->path)).DIRECTORY_SEPARATOR
+            .str_replace('/', DIRECTORY_SEPARATOR, $this->vendorDir).DIRECTORY_SEPARATOR
             .str_replace('/', DIRECTORY_SEPARATOR, $packageName);
     }
 }

--- a/src/Scanners/Composer.php
+++ b/src/Scanners/Composer.php
@@ -142,9 +142,9 @@ class Composer
         }
 
         $config = $json['config'] ?? [];
-        if (is_array($config) && isset($config['vendor-dir']) && is_string($config['vendor-dir'])) {
-            $this->vendorDir = $config['vendor-dir'];
-        }
+        $this->vendorDir = is_array($config) && isset($config['vendor-dir']) && is_string($config['vendor-dir'])
+            ? $config['vendor-dir']
+            : 'vendor';
 
         foreach ((array) ($json['require'] ?? []) as $name => $constraint) {
             $packages[$name] = [
@@ -201,8 +201,16 @@ class Composer
 
     private function computePath(string $packageName): string
     {
+        $vendorPath = str_replace('/', DIRECTORY_SEPARATOR, $this->vendorDir);
+
+        if (DIRECTORY_SEPARATOR === '/' && str_starts_with($vendorPath, DIRECTORY_SEPARATOR)
+            || DIRECTORY_SEPARATOR === '\\' && preg_match('/^[A-Za-z]:[\\\\\\/]/', $vendorPath)) {
+            return $vendorPath.DIRECTORY_SEPARATOR
+                .str_replace('/', DIRECTORY_SEPARATOR, $packageName);
+        }
+
         return realpath(dirname($this->path)).DIRECTORY_SEPARATOR
-            .str_replace('/', DIRECTORY_SEPARATOR, $this->vendorDir).DIRECTORY_SEPARATOR
+            .$vendorPath.DIRECTORY_SEPARATOR
             .str_replace('/', DIRECTORY_SEPARATOR, $packageName);
     }
 }

--- a/tests/Unit/CheckTest.php
+++ b/tests/Unit/CheckTest.php
@@ -19,7 +19,7 @@ it('adds found composer packages to roster class', function () {
     expect($roster->uses(Packages::PINT))->toBeTrue();
     expect($roster->uses(Packages::LARAVEL))->toBeTrue();
     expect($roster->uses(Packages::BOOST))->toBeTrue();
-    expect($roster->uses(Packages::INERTIA))->toBeFalse();
+    expect($roster->uses(Packages::NOVA))->toBeFalse();
 
     expect($roster->usesVersion(Packages::PEST, '3.8.1'))->toBeTrue();
     expect($roster->usesVersion(Packages::PINT, '1.21.2'))->toBeTrue();

--- a/tests/Unit/RosterTest.php
+++ b/tests/Unit/RosterTest.php
@@ -4,6 +4,7 @@ use Laravel\Roster\Approach;
 use Laravel\Roster\Enums\Approaches;
 use Laravel\Roster\Enums\NodePackageManager;
 use Laravel\Roster\Enums\Packages;
+use Laravel\Roster\Enums\PackageSource;
 use Laravel\Roster\Package;
 use Laravel\Roster\Roster;
 
@@ -23,7 +24,7 @@ it('knows if a package is in use', function () {
     $roster = (new Roster)->add($package);
 
     expect($roster->uses(Packages::PEST))->toBeTrue();
-    expect($roster->uses(Packages::INERTIA))->toBeFalse();
+    expect($roster->uses(Packages::NOVA))->toBeFalse();
 });
 
 it('knows if a specific version of a package is in use', function () {
@@ -31,7 +32,7 @@ it('knows if a specific version of a package is in use', function () {
     $roster = (new Roster)->add($usedPackage);
 
     expect($roster->uses(Packages::PEST))->toBeTrue();
-    expect($roster->usesVersion(Packages::INERTIA, '1.0.1'))->toBeFalse();
+    expect($roster->usesVersion(Packages::NOVA, '1.0.1'))->toBeFalse();
     expect($roster->usesVersion(Packages::PEST, '1.0.1'))->toBeTrue();
 
     expect($roster->usesVersion(Packages::PEST, '1.0.1', '='))->toBeTrue();
@@ -65,10 +66,10 @@ it('knows if an approach is in use', function () {
 
 it('can return dev packages', function () {
     $devPackage = new Package(Packages::PEST, 'pestphp/pest', '1.0.1', true);
-    $package = new Package(Packages::INERTIA, 'inertiajs/inertia-laravel', '2.0.0');
+    $package = new Package(Packages::LARAVEL, 'laravel/framework', '2.0.0');
     $roster = (new Roster)->add($devPackage)->add($package);
 
-    expect($roster->uses(Packages::INERTIA))->toBeTrue();
+    expect($roster->uses(Packages::LARAVEL))->toBeTrue();
     expect($roster->uses(Packages::PEST))->toBeTrue();
 
     expect($roster->packages()->dev()->toArray())->toBe([$devPackage]);
@@ -79,7 +80,7 @@ it('can return a specific package', function () {
     $roster = (new Roster)->add($package);
 
     expect($roster->package(Packages::PEST))->toBe($package);
-    expect($roster->package(Packages::INERTIA))->toBeNull();
+    expect($roster->package(Packages::NOVA))->toBeNull();
 });
 
 it('can return raw package name', function () {
@@ -87,6 +88,21 @@ it('can return raw package name', function () {
 
     expect($package->rawName())->toBe('pestphp/pest');
     expect($package->name())->toBe('PEST');
+});
+
+it('has null source and path by default', function () {
+    $package = new Package(Packages::PEST, 'pestphp/pest', '1.0.1');
+
+    expect($package->source())->toBeNull();
+    expect($package->path())->toBeNull();
+});
+
+it('can set and get source and path', function () {
+    $package = new Package(Packages::PEST, 'pestphp/pest', '1.0.1');
+    $package->setSource(PackageSource::COMPOSER)->setPath('/some/path/vendor/pestphp/pest');
+
+    expect($package->source())->toBe(PackageSource::COMPOSER);
+    expect($package->path())->toBe('/some/path/vendor/pestphp/pest');
 });
 
 describe('node package manager detection', function () {

--- a/tests/Unit/Scanners/ComposerTest.php
+++ b/tests/Unit/Scanners/ComposerTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Laravel\Roster\Enums\Packages;
+use Laravel\Roster\Enums\PackageSource;
 use Laravel\Roster\Scanners\Composer;
 
 it('can parse installed packages', function () {
@@ -12,6 +13,8 @@ it('can parse installed packages', function () {
     expect($laravel->isDev())->toBeFalse();
     expect($laravel->direct())->toBeTrue();
     expect($laravel->constraint())->toEqual('^11.0');
+    expect($laravel->source())->toBe(PackageSource::COMPOSER);
+    expect($laravel->path())->toEndWith('vendor'.DIRECTORY_SEPARATOR.'laravel'.DIRECTORY_SEPARATOR.'framework');
 
     $pest = $uses->first(fn ($item) => $item->package() === Packages::PEST);
     expect($pest->version())->toEqual('3.8.1');
@@ -25,11 +28,11 @@ it('can parse installed packages', function () {
     expect($pint->direct())->toBeTrue();
     expect($pint->constraint())->toEqual('^1.20');
 
-    $inertia = $uses->first(fn ($item) => $item->package() === Packages::INERTIA);
+    $inertia = $uses->first(fn ($item) => $item->package() === Packages::INERTIA_LARAVEL);
     expect($inertia)->toBeNull();
 });
 
-it('adds 2 entries for inertia', function () {
+it('adds 1 entry for inertia', function () {
     $composerLockContent = '{
         "packages": [
             {
@@ -50,13 +53,6 @@ it('adds 2 entries for inertia', function () {
     $laravel = $uses->first(fn ($item) => $item->package() === Packages::LARAVEL);
     expect($laravel)->toBeNull();
 
-    // INERTIA is the general package - is it using inertia at all?
-    $inertia = $uses->first(fn ($item) => $item->package() === Packages::INERTIA);
-    expect($inertia->version())->toEqual('123.456.789');
-    expect($inertia->isDev())->toBeFalse();
-    expect($inertia->direct())->toBeFalse();
-
-    // The specific package of Inertia
     $inertia = $uses->first(fn ($item) => $item->package() === Packages::INERTIA_LARAVEL);
     expect($inertia->version())->toEqual('123.456.789');
     expect($inertia->isDev())->toBeFalse();

--- a/tests/Unit/Scanners/ComposerTest.php
+++ b/tests/Unit/Scanners/ComposerTest.php
@@ -70,6 +70,60 @@ it('detects PHPUnit from fixture', function () {
     expect($phpunit->direct())->toBeFalse();
 });
 
+it('respects composer vendor-dir config', function () {
+    $tempDir = sys_get_temp_dir().DIRECTORY_SEPARATOR.'roster_vendor_dir_test_'.uniqid();
+    mkdir($tempDir, 0755, true);
+
+    $composerJson = $tempDir.DIRECTORY_SEPARATOR.'composer.json';
+    $composerLock = $tempDir.DIRECTORY_SEPARATOR.'composer.lock';
+
+    file_put_contents($composerJson, json_encode([
+        'require' => ['laravel/framework' => '^11.0'],
+        'config' => ['vendor-dir' => 'lib/packages'],
+    ]));
+
+    file_put_contents($composerLock, json_encode([
+        'packages' => [['name' => 'laravel/framework', 'version' => 'v11.0.0']],
+        'packages-dev' => [],
+    ]));
+
+    $uses = (new Composer($composerLock))->scan();
+
+    $laravel = $uses->first(fn ($item) => $item->package() === Packages::LARAVEL);
+    expect($laravel->path())->toEndWith('lib'.DIRECTORY_SEPARATOR.'packages'.DIRECTORY_SEPARATOR.'laravel'.DIRECTORY_SEPARATOR.'framework');
+    expect($laravel->path())->not()->toContain(DIRECTORY_SEPARATOR.'vendor'.DIRECTORY_SEPARATOR);
+
+    unlink($composerJson);
+    unlink($composerLock);
+    rmdir($tempDir);
+});
+
+it('defaults to vendor when vendor-dir is not configured', function () {
+    $tempDir = sys_get_temp_dir().DIRECTORY_SEPARATOR.'roster_vendor_dir_test_'.uniqid();
+    mkdir($tempDir, 0755, true);
+
+    $composerJson = $tempDir.DIRECTORY_SEPARATOR.'composer.json';
+    $composerLock = $tempDir.DIRECTORY_SEPARATOR.'composer.lock';
+
+    file_put_contents($composerJson, json_encode([
+        'require' => ['laravel/framework' => '^11.0'],
+    ]));
+
+    file_put_contents($composerLock, json_encode([
+        'packages' => [['name' => 'laravel/framework', 'version' => 'v11.0.0']],
+        'packages-dev' => [],
+    ]));
+
+    $uses = (new Composer($composerLock))->scan();
+
+    $laravel = $uses->first(fn ($item) => $item->package() === Packages::LARAVEL);
+    expect($laravel->path())->toEndWith('vendor'.DIRECTORY_SEPARATOR.'laravel'.DIRECTORY_SEPARATOR.'framework');
+
+    unlink($composerJson);
+    unlink($composerLock);
+    rmdir($tempDir);
+});
+
 it('marks transitive dependencies as indirect', function () {
     $path = __DIR__.'/../../fixtures/fog/composer.lock';
     $uses = (new Composer($path))->scan();

--- a/tests/Unit/Scanners/PackageLockTest.php
+++ b/tests/Unit/Scanners/PackageLockTest.php
@@ -148,6 +148,18 @@ it('handles missing lock files gracefully', function () {
     expect($items)->toBeEmpty();
 });
 
+it('produces absolute npm package paths from relative input', function () {
+    $path = __DIR__.'/../../fixtures/fog/';
+    $packageLock = new PackageLock($path);
+    $items = $packageLock->scan();
+
+    $tailwind = $items->first(fn (Package $package) => $package->package() === Packages::TAILWINDCSS);
+
+    expect($tailwind->path())->toStartWith(DIRECTORY_SEPARATOR);
+    expect($tailwind->path())->not()->toContain('..');
+    expect($tailwind->path())->toEndWith('node_modules'.DIRECTORY_SEPARATOR.'tailwindcss');
+});
+
 it('scans valid bun.lock', function () use ($packageLockPath, $pnpmLockPath, $yarnLockPath, $yarnV1LockPath, $tempPackagePath, $tempPnpmPath, $tempYarnPath, $tempYarnV1Path) {
     // Remove other lock files temporarily to test bun priority
     if (file_exists($packageLockPath)) {

--- a/tests/Unit/Scanners/PackageLockTest.php
+++ b/tests/Unit/Scanners/PackageLockTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Laravel\Roster\Enums\Packages;
+use Laravel\Roster\Enums\PackageSource;
 use Laravel\Roster\Package;
 use Laravel\Roster\Scanners\PackageLock;
 
@@ -38,6 +39,8 @@ it('scans valid package-lock.json', function () {
     $inertiaReact = $items->first(fn (Package $package) => $package->package() === Packages::INERTIA_REACT);
 
     expect($tailwind->version())->toEqual('3.4.16'); // Installed version, not dependency constraint
+    expect($tailwind->source())->toBe(PackageSource::NPM);
+    expect($tailwind->path())->toEndWith('node_modules'.DIRECTORY_SEPARATOR.'tailwindcss');
     expect($inertiaReact)->toBeNull();
 });
 


### PR DESCRIPTION
- Add `source` (composer/npm) and `path` properties to `Package`, allowing consumers to know where each package was installed and locate its files on disk
- Remove compound `INERTIA` and `WAYFINDER` enum cases in favor of specific variants (`INERTIA_LARAVEL`, `INERTIA_REACT`, etc.), simplifying the mapping logic by eliminating the array-of-enums pattern
- Rename `WAYFINDER_LARAVEL` to `WAYFINDER`, since the compound `WAYFINDER` case no longer exists and `laravel/wayfinder` is the primary Composer package
- Add `AI` enum case for the `laravel/ai` package

## Usage

```php
$roster = Roster::scan();

$package = $roster->package(Packages::LARAVEL);

$package->source();  // PackageSource::COMPOSER
$package->path();    // '/absolute/path/to/vendor/laravel/framework'

$package = $roster->package(Packages::TAILWINDCSS);

$package->source();  // PackageSource::NPM
$package->path();    // '/absolute/path/to/node_modules/tailwindcss'
```

Projects with a custom `vendor-dir` in `composer.json` are handled automatically:

```json
{
    "config": {
        "vendor-dir": "lib/packages"
    }
}
```

```php
$package->path(); // '/absolute/path/to/lib/packages/laravel/framework'
```

The `source` and `path` fields are also included in `Roster::json()` output:

```json
{
    "packages": [
        {
            "name": "LARAVEL",
            "version": "11.44.2",
            "source": "composer",
            "path": "/absolute/path/to/vendor/laravel/framework"
        }
    ]
}
```

## Breaking changes

- **Removed `Packages::INERTIA` enum case**
  Use `Packages::INERTIA_LARAVEL`, `Packages::INERTIA_REACT`, `Packages::INERTIA_SVELTE`, or `Packages::INERTIA_VUE` instead

- **Renamed `Packages::WAYFINDER_LARAVEL` to `Packages::WAYFINDER`**
  The old compound `Packages::WAYFINDER` case has been removed; the new `Packages::WAYFINDER` now maps directly to the `laravel/wayfinder` Composer package

- **Scanning Inertia/Wayfinder packages now produces 1 entry instead of 2**
  Previously, scanning `inertiajs/inertia-laravel` produced both `INERTIA` and `INERTIA_LARAVEL`; now it produces only `INERTIA_LARAVEL`. Same applies to `@inertiajs/*` npm packages, `laravel/wayfinder`, and `@laravel/vite-plugin-wayfinder`