### PR TITLE
Add @laravel/echo-react and @laravel/echo-vue package detection

### DIFF
--- a/src/Enums/Packages.php
+++ b/src/Enums/Packages.php
@@ -48,6 +48,8 @@ enum Packages: string
     // NPM
     case ALPINEJS = 'alpinejs';
     case ECHO = 'laravel-echo';
+    case ECHO_REACT = 'echo-react';
+    case ECHO_VUE = 'echo-vue';
     case ESLINT = 'eslint';
     case INERTIA_REACT = 'inertia-react';
     case INERTIA_SVELTE = 'inertia-svelte';

--- a/src/Scanners/BasePackageScanner.php
+++ b/src/Scanners/BasePackageScanner.php
@@ -24,6 +24,8 @@ abstract class BasePackageScanner
         '@inertiajs/svelte' => Packages::INERTIA_SVELTE,
         '@inertiajs/vue3' => Packages::INERTIA_VUE,
         'laravel-echo' => Packages::ECHO,
+        '@laravel/echo-react' => Packages::ECHO_REACT,
+        '@laravel/echo-vue' => Packages::ECHO_VUE,
         '@laravel/vite-plugin-wayfinder' => Packages::WAYFINDER_VITE,
         'prettier' => Packages::PRETTIER,
         'react' => Packages::REACT,

--- a/tests/Unit/CheckTest.php
+++ b/tests/Unit/CheckTest.php
@@ -8,8 +8,8 @@ it('adds found composer packages to roster class', function () {
 
     $roster = Roster::scan($path);
 
-    // Overall - 12 packages from composer (dusk, socialite, folio, volt, fluxui_free, laravel, pest, pint, filament, livewire, flux, phpunit, boost) and 2 from package lock (tailwind, alpine)
-    expect($roster->packages())->toHaveCount(16);
+    // Overall - 12 packages from composer (dusk, socialite, folio, volt, fluxui_free, laravel, pest, pint, filament, livewire, flux, phpunit, boost) and 4 from package lock (tailwind, alpine, echo-react, echo-vue)
+    expect($roster->packages())->toHaveCount(18);
 
     // From composer
     expect($roster->uses(Packages::PEST))->toBeTrue();

--- a/tests/Unit/Scanners/PackageLockTest.php
+++ b/tests/Unit/Scanners/PackageLockTest.php
@@ -37,11 +37,21 @@ it('scans valid package-lock.json', function () {
 
     $tailwind = $items->first(fn (Package $package) => $package->package() === Packages::TAILWINDCSS);
     $inertiaReact = $items->first(fn (Package $package) => $package->package() === Packages::INERTIA_REACT);
+    $echoReact = $items->first(fn (Package $package) => $package->package() === Packages::ECHO_REACT);
+    $echoVue = $items->first(fn (Package $package) => $package->package() === Packages::ECHO_VUE);
 
     expect($tailwind->version())->toEqual('3.4.16'); // Installed version, not dependency constraint
     expect($tailwind->source())->toBe(PackageSource::NPM);
     expect($tailwind->path())->toEndWith('node_modules'.DIRECTORY_SEPARATOR.'tailwindcss');
     expect($inertiaReact)->toBeNull();
+    expect($echoReact)->not->toBeNull();
+    expect($echoReact->version())->toEqual('0.1.0');
+    expect($echoReact->source())->toBe(PackageSource::NPM);
+    expect($echoReact->path())->toEndWith('node_modules'.DIRECTORY_SEPARATOR.'@laravel'.DIRECTORY_SEPARATOR.'echo-react');
+    expect($echoVue)->not->toBeNull();
+    expect($echoVue->version())->toEqual('0.1.0');
+    expect($echoVue->source())->toBe(PackageSource::NPM);
+    expect($echoVue->path())->toEndWith('node_modules'.DIRECTORY_SEPARATOR.'@laravel'.DIRECTORY_SEPARATOR.'echo-vue');
 });
 
 it('detects direct and indirect dependencies with constraints from package.json', function () {

--- a/tests/fixtures/fog/bun.lock
+++ b/tests/fixtures/fog/bun.lock
@@ -7,11 +7,17 @@
         "tailwindcss": "^3.4.3",
       },
       "devDependencies": {
+        "@laravel/echo-react": "^0.1.0",
+        "@laravel/echo-vue": "^0.1.0",
         "alpinejs": "3.14.8",
       },
     },
   },
   "packages": {
+    "@laravel/echo-react": ["@laravel/echo-react@0.1.0", "", {}, "sha512-abc123=="],
+
+    "@laravel/echo-vue": ["@laravel/echo-vue@0.1.0", "", {}, "sha512-def456=="],
+
     "@vue/reactivity": ["@vue/reactivity@3.1.5", "", { "dependencies": { "@vue/shared": "3.1.5" } }, "sha512-1tdfLmNjWG6t/CsPldh+foumYFo3cpyCHgBYQ34ylaMsJ+SNHQ1kApMIa8jN+i593zQuaw3AdWH0nJTARzCFhg=="],
 
     "@vue/shared": ["@vue/shared@3.1.5", "", {}, "sha512-oJ4F3TnvpXaQwZJNF3ZK+kLPHKarDmJjJ6jyzVNDKH9md1dptjC7lWR//jrGuLdek/U6iltWxqAnYOu8gCiOvA=="],

--- a/tests/fixtures/fog/package-lock.json
+++ b/tests/fixtures/fog/package-lock.json
@@ -12,6 +12,8 @@
                 "puppeteer": "^24.2.0"
             },
             "devDependencies": {
+                "@laravel/echo-react": "^0.1.0",
+                "@laravel/echo-vue": "^0.1.0",
                 "@tailwindcss/forms": "^0.5.7",
                 "@tailwindcss/typography": "^0.5.12",
                 "alpinejs": "^3.14.8",
@@ -861,6 +863,20 @@
             "os": [
                 "win32"
             ]
+        },
+        "node_modules/@laravel/echo-react": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/@laravel/echo-react/-/echo-react-0.1.0.tgz",
+            "integrity": "sha512-abc123==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@laravel/echo-vue": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/@laravel/echo-vue/-/echo-vue-0.1.0.tgz",
+            "integrity": "sha512-def456==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@ryangjchandler/alpine-clipboard": {
             "version": "2.3.0",

--- a/tests/fixtures/fog/package.json
+++ b/tests/fixtures/fog/package.json
@@ -9,6 +9,8 @@
         "tailwindcss": "^3.4.3"
     },
     "devDependencies": {
+        "@laravel/echo-react": "^0.1.0",
+        "@laravel/echo-vue": "^0.1.0",
         "@tailwindcss/forms": "^0.5.7",
         "@tailwindcss/typography": "^0.5.12",
         "alpinejs": "^3.14.8",

--- a/tests/fixtures/fog/pnpm-lock.yaml
+++ b/tests/fixtures/fog/pnpm-lock.yaml
@@ -12,6 +12,12 @@ importers:
         specifier: 3.4.3
         version: 3.4.3
     devDependencies:
+      '@laravel/echo-react':
+        specifier: ^0.1.0
+        version: 0.1.0
+      '@laravel/echo-vue':
+        specifier: ^0.1.0
+        version: 0.1.0
       alpinejs:
         specifier: ^3.14.8
         version: 3.14.8
@@ -21,6 +27,12 @@ packages:
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@laravel/echo-react@0.1.0':
+    resolution: {integrity: sha512-abc123==}
+
+  '@laravel/echo-vue@0.1.0':
+    resolution: {integrity: sha512-def456==}
 
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -446,6 +458,10 @@ packages:
 snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
+
+  '@laravel/echo-react@0.1.0': {}
+
+  '@laravel/echo-vue@0.1.0': {}
 
   '@isaacs/cliui@8.0.2':
     dependencies:

--- a/tests/fixtures/fog/yarn.lock
+++ b/tests/fixtures/fog/yarn.lock
@@ -369,6 +369,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@laravel/echo-react@npm:^0.1.0":
+  version: 0.1.0
+  resolution: "@laravel/echo-react@npm:0.1.0"
+  checksum: 10c0-abc123
+  languageName: node
+  linkType: hard
+
+"@laravel/echo-vue@npm:^0.1.0":
+  version: 0.1.0
+  resolution: "@laravel/echo-vue@npm:0.1.0"
+  checksum: 10c0-def456
+  languageName: node
+  linkType: hard
+
 "@inertiajs/core@npm:2.2.15":
   version: 2.2.15
   resolution: "@inertiajs/core@npm:2.2.15"
@@ -3352,6 +3366,8 @@ __metadata:
   dependencies:
     "@eslint/js": "npm:^9.19.0"
     "@inertiajs/vue3": "npm:^2.0.0"
+    "@laravel/echo-react": "npm:^0.1.0"
+    "@laravel/echo-vue": "npm:^0.1.0"
     "@laravel/vite-plugin-wayfinder": "npm:^0.1.3"
     "@rollup/rollup-linux-x64-gnu": "npm:4.9.5"
     "@tailwindcss/oxide-linux-x64-gnu": "npm:^4.0.1"


### PR DESCRIPTION
`@laravel/echo-react` and `@laravel/echo-vue` are new npm packages that Roster doesn't detect yet. The existing `ECHO` case only covers the `laravel-echo` package.

### Approach

- Added `ECHO_REACT` and `ECHO_VUE` enum cases and scanner mappings, following the same pattern used for Inertia framework variants
- Updated all five lock file fixtures (npm, pnpm, yarn v1/v4, bun) and added test assertions to verify detection