### PR TITLE
Add source convention detection via Project::approaches

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,36 @@ $system->js()->packageManagers()->isInstalled(JsPackageManager::BUN);
 $system->js()->packageManagers()->all();
 ```
 
+### Approaches
+
+The `approaches` method inspects the project's **own source code** — not its manifests — and reports which stylistic conventions the application has adopted: `$fillable` vs `$guarded` mass assignment, enum case casing, pipe vs array validation rule syntax, and `#[Scope]` vs `scopeXxx()` query scopes:
+
+```php
+use Laravel\Roster\Enums\Approach;
+
+$project->approaches()->uses(Approach::MASS_ASSIGNMENT_FILLABLE); // is this the dominant style?
+$project->approaches()->uses([                                    // any-of, like EnumSet
+    Approach::VALIDATION_PIPE_SYNTAX,
+    Approach::VALIDATION_ARRAY_SYNTAX,
+]);
+$project->approaches()->all();                                    // Collection<string, ApproachResult>
+```
+
+An approach is only reported when it is backed by enough evidence: at least 5 votes (one per model, enum case, form request, or scope), and a Wilson score lower bound (95% confidence) of at least 0.5 for the winning style — so a 4/5 majority is rejected, 90/100 passes, and an evenly split codebase stays silent.
+
+Each `ApproachResult` exposes the winning `approach`, its raw `confidence` ratio, the `matched` and `total` vote counts, and the `paths` of the files that voted:
+
+```php
+$result = $project->approaches()->all()->get(Approach::MASS_ASSIGNMENT_FILLABLE->value);
+
+$result->confidence; // 0.9
+$result->matched;    // 9
+$result->total;      // 10
+$result->paths;      // ['/app/Models/User.php', ...]
+```
+
+Source files are discovered from the `composer.json` PSR-4 autoload roots unioned with `app/`, and subdirectories such as `Models/` are matched anywhere beneath a root, so modular layouts like `src/Domain/Orders/Models/` are sampled too. `vendor/`, `node_modules/`, and hidden directories are always excluded. Because source files change without touching any lockfile, approaches are never persisted with the cached scan — they are computed lazily per process, and only when you ask for them: `toArray()` and `json()` stay cheap and omit them, while `roster:scan` accepts an `--approaches` flag to include them in its output.
+
 ## Upgrading
 
 See [UPGRADE.md](UPGRADE.md) for migrating from 0.x.

--- a/pint.json
+++ b/pint.json
@@ -1,5 +1,8 @@
 {
     "preset": "laravel",
+    "exclude": [
+        "tests/fixtures"
+    ],
     "rules": {
         "global_namespace_import": {
             "import_classes": true,

--- a/rector.php
+++ b/rector.php
@@ -14,6 +14,7 @@ return RectorConfig::configure()
         __DIR__.'/tests',
     ])
     ->withSkip([
+        __DIR__.'/tests/fixtures',
         ReadOnlyPropertyRector::class,
         EncapsedStringsToSprintfRector::class,
         NewlineBetweenClassLikeStmtsRector::class,

--- a/src/ApproachResult.php
+++ b/src/ApproachResult.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Roster;
+
+use Laravel\Roster\Enums\Approach;
+
+class ApproachResult
+{
+    /**
+     * @param  float  $confidence  Raw winning ratio (matched / total).
+     * @param  int  $matched  Votes cast for the winning style.
+     * @param  int  $total  Votes cast across all competing styles.
+     * @param  list<string>  $paths  Absolute paths of the files that voted.
+     */
+    public function __construct(
+        public readonly Approach $approach,
+        public readonly float $confidence,
+        public readonly int $matched,
+        public readonly int $total,
+        public readonly array $paths,
+    ) {}
+
+    /**
+     * @return array{approach: string, confidence: float, matched: int, total: int, paths: list<string>}
+     */
+    public function toArray(): array
+    {
+        return [
+            'approach' => $this->approach->value,
+            'confidence' => $this->confidence,
+            'matched' => $this->matched,
+            'total' => $this->total,
+            'paths' => $this->paths,
+        ];
+    }
+}

--- a/src/Console/ScanCommand.php
+++ b/src/Console/ScanCommand.php
@@ -5,14 +5,15 @@ declare(strict_types=1);
 namespace Laravel\Roster\Console;
 
 use Illuminate\Console\Command;
+use Laravel\Roster\ApproachResult;
 use Laravel\Roster\Project;
 use Laravel\Roster\System;
 
 class ScanCommand extends Command
 {
-    protected $signature = 'roster:scan {directory} {--no-system : Skip system probes}';
+    protected $signature = 'roster:scan {directory} {--approaches : Detect source-code approaches (scans every PHP source file)} {--no-system : Skip system probes}';
 
-    protected $description = 'Detect packages, stacks, frameworks, and agents in use and output as JSON';
+    protected $description = 'Detect packages, stacks, frameworks, agents, and approaches in use and output as JSON';
 
     public function handle(): int
     {
@@ -30,7 +31,14 @@ class ScanCommand extends Command
             return self::FAILURE;
         }
 
-        $payload = Project::scan($directory)->toArray();
+        $project = Project::scan($directory);
+        $payload = $project->toArray();
+
+        if ($this->option('approaches')) {
+            $payload['approaches'] = $project->approaches()->all()
+                ->map(fn (ApproachResult $result): array => $result->toArray())
+                ->all();
+        }
 
         if (! $this->option('no-system')) {
             $payload['system'] = System::scan()->toArray();

--- a/src/Detectors/ApproachesDetector.php
+++ b/src/Detectors/ApproachesDetector.php
@@ -1,0 +1,327 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Roster\Detectors;
+
+use Laravel\Roster\ApproachResult;
+use Laravel\Roster\Enums\Approach;
+use Laravel\Roster\Support\SourceFiles;
+
+/**
+ * Detects the stylistic conventions the application's own source code has
+ * adopted. Each detector tallies votes for competing styles and only reports
+ * a winner backed by enough evidence: at least MIN_SAMPLE votes and a Wilson
+ * score lower bound (95% CI) of at least WILSON_FLOOR for the winner's
+ * proportion — so 4/5 is rejected, 90/100 passes, and a split stays silent.
+ */
+class ApproachesDetector
+{
+    /** Minimum number of votes before a style is considered at all. */
+    protected const MIN_SAMPLE = 5;
+
+    /** Gate on the Wilson lower bound rather than the raw ratio, so a small sample cannot over-claim (9/10 ≠ 90/100). */
+    protected const WILSON_FLOOR = 0.5;
+
+    /** z for a 95% confidence interval. */
+    protected const Z = 1.96;
+
+    public function __construct(protected SourceFiles $files) {}
+
+    /**
+     * @return list<ApproachResult>
+     */
+    public static function detect(string $basePath): array
+    {
+        return (new self(new SourceFiles($basePath)))->all();
+    }
+
+    /**
+     * @return list<ApproachResult>
+     */
+    public function all(): array
+    {
+        return array_values(array_filter([
+            $this->massAssignment(),
+            $this->enumCasing(),
+            $this->validationSyntax(),
+            $this->queryScopes(),
+        ]));
+    }
+
+    /**
+     * One vote per model: `protected $fillable` vs `protected $guarded`.
+     * Models declaring both or neither abstain.
+     */
+    protected function massAssignment(): ?ApproachResult
+    {
+        $tally = [
+            Approach::MASS_ASSIGNMENT_FILLABLE->value => 0,
+            Approach::MASS_ASSIGNMENT_GUARDED->value => 0,
+        ];
+        $paths = [];
+
+        foreach ($this->files->php('Models') as $path) {
+            $contents = $this->files->contents($path);
+
+            $fillable = preg_match('/protected\s+\$fillable\b/', $contents) === 1;
+            $guarded = preg_match('/protected\s+\$guarded\b/', $contents) === 1;
+
+            if ($fillable === $guarded) {
+                continue;
+            }
+
+            $tally[$fillable ? Approach::MASS_ASSIGNMENT_FILLABLE->value : Approach::MASS_ASSIGNMENT_GUARDED->value]++;
+            $paths[] = $path;
+        }
+
+        return $this->dominant($tally, $paths);
+    }
+
+    /**
+     * One vote per enum case (not per file), classified by name casing.
+     */
+    protected function enumCasing(): ?ApproachResult
+    {
+        $tally = [
+            Approach::ENUM_CASE_SCREAMING_SNAKE->value => 0,
+            Approach::ENUM_CASE_PASCAL->value => 0,
+            Approach::ENUM_CASE_CAMEL->value => 0,
+        ];
+        $paths = [];
+
+        foreach ($this->files->php() as $path) {
+            if (! $this->files->contains($path, 'enum')) {
+                continue;
+            }
+
+            $names = $this->enumCaseNames($this->files->contents($path));
+
+            if ($names === []) {
+                continue;
+            }
+
+            $paths[] = $path;
+
+            foreach ($names as $name) {
+                $style = $this->classifyCase($name);
+
+                if ($style instanceof Approach) {
+                    $tally[$style->value]++;
+                }
+            }
+        }
+
+        return $this->dominant($tally, $paths);
+    }
+
+    /**
+     * One vote per Form Request with a rules() method: pipe strings
+     * (`'required|max:255'`) vs arrays (`['required', 'max:255']`), the
+     * dominant local notation deciding each file's vote.
+     */
+    protected function validationSyntax(): ?ApproachResult
+    {
+        $tally = [
+            Approach::VALIDATION_PIPE_SYNTAX->value => 0,
+            Approach::VALIDATION_ARRAY_SYNTAX->value => 0,
+        ];
+        $paths = [];
+
+        foreach ($this->files->php('Http/Requests') as $path) {
+            $contents = $this->files->contents($path);
+
+            if (! str_contains($contents, 'function rules')) {
+                continue;
+            }
+
+            $pipe = (int) preg_match_all("/=>\s*'[^']*\|[^']*'/", $contents);
+            $array = (int) preg_match_all("/=>\s*\[\s*'/", $contents);
+
+            if ($pipe === $array) {
+                continue;
+            }
+
+            $tally[$pipe > $array ? Approach::VALIDATION_PIPE_SYNTAX->value : Approach::VALIDATION_ARRAY_SYNTAX->value]++;
+            $paths[] = $path;
+        }
+
+        return $this->dominant($tally, $paths);
+    }
+
+    /**
+     * One vote per query scope: the `#[Scope]` attribute vs `scopeXxx()` naming.
+     */
+    protected function queryScopes(): ?ApproachResult
+    {
+        $tally = [
+            Approach::QUERY_SCOPE_ATTRIBUTE->value => 0,
+            Approach::QUERY_SCOPE_METHOD->value => 0,
+        ];
+        $paths = [];
+
+        foreach ($this->files->php('Models') as $path) {
+            $contents = $this->files->contents($path);
+
+            $attribute = (int) preg_match_all('/#\[\s*Scope\s*\]/', $contents);
+            $method = (int) preg_match_all('/function\s+scope[A-Z]\w*\s*\(/', $contents);
+
+            if ($attribute === 0 && $method === 0) {
+                continue;
+            }
+
+            $tally[Approach::QUERY_SCOPE_ATTRIBUTE->value] += $attribute;
+            $tally[Approach::QUERY_SCOPE_METHOD->value] += $method;
+            $paths[] = $path;
+        }
+
+        return $this->dominant($tally, $paths);
+    }
+
+    /**
+     * Reduce a style tally to its dominant winner, or null when there is too
+     * little evidence or the styles are mixed. Gating uses the Wilson score
+     * lower bound; the reported confidence is the raw ratio.
+     *
+     * @param  array<string, int>  $tally  approach value => votes
+     * @param  list<string>  $paths
+     */
+    protected function dominant(array $tally, array $paths): ?ApproachResult
+    {
+        $tally = array_filter($tally, fn (int $votes): bool => $votes > 0);
+        $total = array_sum($tally);
+
+        if ($total < self::MIN_SAMPLE) {
+            return null;
+        }
+
+        arsort($tally);
+        $winner = (string) array_key_first($tally);
+        $votes = $tally[$winner];
+
+        if ($this->wilsonLower($votes, $total) < self::WILSON_FLOOR) {
+            return null;
+        }
+
+        return new ApproachResult(
+            approach: Approach::from($winner),
+            confidence: $votes / $total,
+            matched: $votes,
+            total: $total,
+            paths: $paths,
+        );
+    }
+
+    /**
+     * Lower bound of the Wilson score interval for a binomial proportion.
+     */
+    protected function wilsonLower(int $successes, int $total): float
+    {
+        if ($total === 0) {
+            return 0.0;
+        }
+
+        $z = self::Z;
+        $z2 = $z * $z;
+        $phat = $successes / $total;
+
+        $center = ($phat + $z2 / (2 * $total)) / (1 + $z2 / $total);
+        $margin = ($z / (1 + $z2 / $total)) * sqrt($phat * (1 - $phat) / $total + $z2 / (4 * $total * $total));
+
+        return $center - $margin;
+    }
+
+    /**
+     * Collect enum case names via a token scan that tracks brace depth, so
+     * `case` labels inside `switch` bodies and the word "enum" in comments or
+     * strings are never mistaken for enum cases.
+     *
+     * @return list<string>
+     */
+    protected function enumCaseNames(string $code): array
+    {
+        $tokens = @token_get_all($code);
+        $names = [];
+        $depth = 0;
+        $pendingEnum = false;
+        $enumBodyDepths = [];
+
+        for ($i = 0, $count = count($tokens); $i < $count; $i++) {
+            $token = $tokens[$i];
+
+            if (is_array($token)) {
+                // String interpolation openers count as `{` — their closing
+                // brace arrives as a plain `}` token and must stay balanced.
+                if ($token[0] === T_CURLY_OPEN || $token[0] === T_DOLLAR_OPEN_CURLY_BRACES) {
+                    $depth++;
+                } elseif ($token[0] === T_ENUM) {
+                    $pendingEnum = true;
+                } elseif ($token[0] === T_CASE && $enumBodyDepths !== [] && end($enumBodyDepths) === $depth) {
+                    $name = $this->nextIdentifier($tokens, $i);
+
+                    if ($name !== null) {
+                        $names[] = $name;
+                    }
+                }
+
+                continue;
+            }
+
+            if ($token === '{') {
+                $depth++;
+
+                if ($pendingEnum) {
+                    $enumBodyDepths[] = $depth;
+                    $pendingEnum = false;
+                }
+            } elseif ($token === '}') {
+                if ($enumBodyDepths !== [] && end($enumBodyDepths) === $depth) {
+                    array_pop($enumBodyDepths);
+                }
+
+                $depth--;
+            }
+        }
+
+        return $names;
+    }
+
+    /**
+     * @param  array<int, array{0: int, 1: string, 2: int}|string>  $tokens
+     */
+    protected function nextIdentifier(array $tokens, int $from): ?string
+    {
+        for ($i = $from + 1, $count = count($tokens); $i < $count; $i++) {
+            $token = $tokens[$i];
+
+            if (is_array($token)) {
+                if (in_array($token[0], [T_WHITESPACE, T_COMMENT, T_DOC_COMMENT], true)) {
+                    continue;
+                }
+
+                return $token[0] === T_STRING ? $token[1] : null;
+            }
+
+            return null;
+        }
+
+        return null;
+    }
+
+    protected function classifyCase(string $name): ?Approach
+    {
+        if (preg_match('/^[A-Z0-9]+(_[A-Z0-9]+)*$/', $name) === 1 && preg_match('/[A-Z]/', $name) === 1) {
+            return Approach::ENUM_CASE_SCREAMING_SNAKE;
+        }
+
+        if (preg_match('/^[A-Z][a-zA-Z0-9]*$/', $name) === 1) {
+            return Approach::ENUM_CASE_PASCAL;
+        }
+
+        if (preg_match('/^[a-z][a-zA-Z0-9]*$/', $name) === 1) {
+            return Approach::ENUM_CASE_CAMEL;
+        }
+
+        return null;
+    }
+}

--- a/src/Enums/Approach.php
+++ b/src/Enums/Approach.php
@@ -9,4 +9,13 @@ enum Approach: string
     case ACTION = 'action';
     case DDD = 'ddd';
     case MODULAR = 'modular';
+    case MASS_ASSIGNMENT_FILLABLE = 'mass-assignment-fillable';
+    case MASS_ASSIGNMENT_GUARDED = 'mass-assignment-guarded';
+    case ENUM_CASE_SCREAMING_SNAKE = 'enum-case-screaming-snake';
+    case ENUM_CASE_PASCAL = 'enum-case-pascal';
+    case ENUM_CASE_CAMEL = 'enum-case-camel';
+    case VALIDATION_PIPE_SYNTAX = 'validation-pipe-syntax';
+    case VALIDATION_ARRAY_SYNTAX = 'validation-array-syntax';
+    case QUERY_SCOPE_ATTRIBUTE = 'query-scope-attribute';
+    case QUERY_SCOPE_METHOD = 'query-scope-method';
 }

--- a/src/Facades/Project.php
+++ b/src/Facades/Project.php
@@ -21,6 +21,7 @@ use Laravel\Roster\ProjectManager;
  * @method static \Laravel\Roster\Support\EnumSet<\Laravel\Roster\Enums\Agent> agents()
  * @method static \Laravel\Roster\Support\EnumSet<\Laravel\Roster\Enums\Editor> editors()
  * @method static \Laravel\Roster\Support\EnumSet<\Laravel\Roster\Enums\Approach> approach()
+ * @method static \Laravel\Roster\Support\ApproachSet approaches()
  * @method static string json()
  *
  * @see ProjectManager

--- a/src/Project.php
+++ b/src/Project.php
@@ -7,6 +7,7 @@ namespace Laravel\Roster;
 use Illuminate\Support\Str;
 use Laravel\Roster\Detectors\AgentsDetector;
 use Laravel\Roster\Detectors\ApproachDetector;
+use Laravel\Roster\Detectors\ApproachesDetector;
 use Laravel\Roster\Detectors\BrowserTestFrameworkDetector;
 use Laravel\Roster\Detectors\EditorsDetector;
 use Laravel\Roster\Detectors\FrontendDetector;
@@ -21,10 +22,13 @@ use Laravel\Roster\Enums\Frontend;
 use Laravel\Roster\Enums\Stack;
 use Laravel\Roster\Scanners\Composer;
 use Laravel\Roster\Scanners\JsLockfile;
+use Laravel\Roster\Support\ApproachSet;
 use Laravel\Roster\Support\EnumSet;
 
 class Project
 {
+    protected ?ApproachSet $approaches = null;
+
     /**
      * @param  EnumSet<Stack>  $stack
      * @param  EnumSet<BrowserTestFramework>  $browserTestFrameworks
@@ -34,6 +38,7 @@ class Project
      * @param  EnumSet<Approach>  $approach
      */
     public function __construct(
+        protected string $basePath,
         protected PhpEcosystem $php,
         protected JsEcosystem $js,
         protected EnumSet $stack,
@@ -90,6 +95,16 @@ class Project
         return $this->approach;
     }
 
+    /**
+     * The stylistic conventions the project's own source code has adopted.
+     * Computed lazily and never persisted with the cached scan — source files
+     * change without touching any lockfile the scan cache is keyed on.
+     */
+    public function approaches(): ApproachSet
+    {
+        return $this->approaches ??= new ApproachSet(ApproachesDetector::detect($this->basePath));
+    }
+
     public static function scan(?string $basePath = null): self
     {
         $basePath = self::normalizeBasePath($basePath);
@@ -103,6 +118,7 @@ class Project
         $js = new JsEcosystem($jsPackages, $jsLockfile->committedManager());
 
         return new self(
+            $basePath,
             $php,
             $js,
             new EnumSet(StackDetector::detect($php, $js)),
@@ -142,5 +158,33 @@ class Project
     public function json(): string
     {
         return json_encode($this->toArray(), JSON_PRETTY_PRINT) ?: '{}';
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function __serialize(): array
+    {
+        $properties = get_object_vars($this);
+        unset($properties['approaches']);
+
+        return $properties;
+    }
+
+    /**
+     * @param  array{basePath: string, php: PhpEcosystem, js: JsEcosystem, stack: EnumSet<Stack>, browserTestFrameworks: EnumSet<BrowserTestFramework>, frontend: EnumSet<Frontend>, agents: EnumSet<Agent>, editors: EnumSet<Editor>, approach: EnumSet<Approach>}  $properties
+     */
+    public function __unserialize(array $properties): void
+    {
+        $this->basePath = $properties['basePath'];
+        $this->php = $properties['php'];
+        $this->js = $properties['js'];
+        $this->stack = $properties['stack'];
+        $this->browserTestFrameworks = $properties['browserTestFrameworks'];
+        $this->frontend = $properties['frontend'];
+        $this->agents = $properties['agents'];
+        $this->editors = $properties['editors'];
+        $this->approach = $properties['approach'];
+        $this->approaches = null;
     }
 }

--- a/src/ProjectManager.php
+++ b/src/ProjectManager.php
@@ -16,6 +16,7 @@ use Laravel\Roster\Enums\BrowserTestFramework;
 use Laravel\Roster\Enums\Editor;
 use Laravel\Roster\Enums\Frontend;
 use Laravel\Roster\Enums\Stack;
+use Laravel\Roster\Support\ApproachSet;
 use Laravel\Roster\Support\CachesScan;
 use Laravel\Roster\Support\EnumSet;
 
@@ -96,6 +97,11 @@ class ProjectManager
     public function approach(): EnumSet
     {
         return $this->instance()->approach();
+    }
+
+    public function approaches(): ApproachSet
+    {
+        return $this->instance()->approaches();
     }
 
     public function json(): string

--- a/src/Support/ApproachSet.php
+++ b/src/Support/ApproachSet.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Roster\Support;
+
+use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
+use Laravel\Roster\ApproachResult;
+use Laravel\Roster\Enums\Approach;
+
+class ApproachSet
+{
+    /** @var Collection<string, ApproachResult> */
+    protected Collection $results;
+
+    /**
+     * @param  array<int, ApproachResult>  $results
+     */
+    public function __construct(array $results)
+    {
+        /** @var Collection<string, ApproachResult> $keyed */
+        $keyed = (new Collection($results))
+            ->keyBy(fn (ApproachResult $result): string => $result->approach->value);
+
+        $this->results = $keyed;
+    }
+
+    /**
+     * Whether any of the given approaches is the project's confidently-detected
+     * dominant style.
+     *
+     * @param  Approach|array<int, Approach>  $approach
+     */
+    public function uses(Approach|array $approach): bool
+    {
+        foreach (Arr::wrap($approach) as $needle) {
+            if ($this->results->has($needle->value)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * All confidently-detected approaches, keyed by approach value.
+     *
+     * @return Collection<string, ApproachResult>
+     */
+    public function all(): Collection
+    {
+        return $this->results;
+    }
+}

--- a/src/Support/SourceFiles.php
+++ b/src/Support/SourceFiles.php
@@ -1,0 +1,209 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Roster\Support;
+
+use Illuminate\Support\Str;
+use RecursiveCallbackFilterIterator;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use SplFileInfo;
+use UnexpectedValueException;
+
+/**
+ * Enumerates the application's own PHP source files from its composer.json
+ * PSR-4 autoload roots unioned with app/, deduped by real path.
+ */
+class SourceFiles
+{
+    protected string $basePath;
+
+    /** @var list<string>|null */
+    protected ?array $roots = null;
+
+    /** @var array<string, string> */
+    protected array $contents = [];
+
+    /** @var array<string, list<string>> */
+    protected array $filesByRoot = [];
+
+    public function __construct(string $basePath)
+    {
+        $this->basePath = Str::finish($basePath, DIRECTORY_SEPARATOR);
+    }
+
+    /**
+     * PHP files across every source root. When a subpath is given it matches
+     * anywhere beneath the root (`(^|/)Models/`), so modular layouts like
+     * `src/Domain/Orders/Models/Order.php` are sampled — not just `app/Models/`.
+     * A root that is itself the target directory (e.g. a PSR-4 mapping straight
+     * into `src/Models`) is not matched — the subpath must appear beneath it.
+     *
+     * @return list<string>
+     */
+    public function php(?string $subpath = null): array
+    {
+        $pattern = $subpath === null
+            ? null
+            : '#(^|/)'.preg_quote(trim(str_replace('\\', '/', $subpath), '/'), '#').'/#';
+
+        $files = [];
+
+        foreach ($this->roots() as $root) {
+            foreach ($this->phpFilesIn($root) as $file) {
+                $relative = str_replace('\\', '/', substr($file, strlen($root) + 1));
+
+                if ($pattern !== null && preg_match($pattern, $relative) !== 1) {
+                    continue;
+                }
+
+                $files[realpath($file) ?: $file] = $file;
+            }
+        }
+
+        $files = array_values($files);
+        sort($files);
+
+        return $files;
+    }
+
+    /**
+     * Cheap containment check that does not populate the content cache — used
+     * to skip files before a heavier parse without retaining every scanned
+     * file's bytes.
+     */
+    public function contains(string $path, string $needle): bool
+    {
+        if (array_key_exists($path, $this->contents)) {
+            return stripos($this->contents[$path], $needle) !== false;
+        }
+
+        $contents = $this->read($path);
+
+        return $contents !== false && stripos($contents, $needle) !== false;
+    }
+
+    public function contents(string $path): string
+    {
+        if (! array_key_exists($path, $this->contents)) {
+            $contents = $this->read($path);
+            $this->contents[$path] = $contents === false ? '' : $contents;
+        }
+
+        return $this->contents[$path];
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function roots(): array
+    {
+        return $this->roots ??= $this->resolveRoots();
+    }
+
+    protected function read(string $path): string|false
+    {
+        return is_file($path) ? @file_get_contents($path) : false;
+    }
+
+    /**
+     * @return list<string>
+     */
+    protected function resolveRoots(): array
+    {
+        $existing = [];
+
+        foreach ([...$this->psr4Roots(), $this->basePath.'app'] as $root) {
+            $real = realpath(rtrim($root, '/\\'));
+            if ($real === false) {
+                continue;
+            }
+
+            if (! is_dir($real)) {
+                continue;
+            }
+
+            $existing[$real] = $real;
+        }
+
+        return array_values($existing);
+    }
+
+    /**
+     * @return list<string>
+     */
+    protected function psr4Roots(): array
+    {
+        $path = $this->basePath.'composer.json';
+
+        if (! is_file($path)) {
+            return [];
+        }
+
+        $data = json_decode((string) file_get_contents($path), true);
+
+        if (! is_array($data)) {
+            return [];
+        }
+
+        $autoload = $data['autoload'] ?? null;
+        $psr4 = is_array($autoload) && is_array($autoload['psr-4'] ?? null) ? $autoload['psr-4'] : [];
+
+        $roots = [];
+
+        foreach ($psr4 as $paths) {
+            foreach (is_array($paths) ? $paths : [$paths] as $relative) {
+                if (is_string($relative) && $relative !== '') {
+                    $roots[] = $this->basePath.str_replace('/', DIRECTORY_SEPARATOR, trim($relative, '/'));
+                }
+            }
+        }
+
+        return $roots;
+    }
+
+    /**
+     * @return list<string>
+     */
+    protected function phpFilesIn(string $root): array
+    {
+        return $this->filesByRoot[$root] ??= $this->enumeratePhpFiles($root);
+    }
+
+    /**
+     * Walks a root for PHP files, pruning dependency and hidden directories so
+     * a PSR-4 mapping that resolves to the project root (e.g. `"App\\": "."`)
+     * cannot let vendor code vote on the application's conventions.
+     *
+     * @return list<string>
+     */
+    protected function enumeratePhpFiles(string $root): array
+    {
+        $files = [];
+
+        try {
+            $iterator = new RecursiveIteratorIterator(
+                new RecursiveCallbackFilterIterator(
+                    new RecursiveDirectoryIterator($root, RecursiveDirectoryIterator::SKIP_DOTS),
+                    fn (SplFileInfo $file): bool => ! ($file->isDir() && (
+                        str_starts_with($file->getFilename(), '.')
+                        || in_array($file->getFilename(), ['vendor', 'node_modules'], true)
+                    )),
+                ),
+            );
+
+            foreach ($iterator as $file) {
+                if ($file instanceof SplFileInfo && $file->isFile() && strtolower($file->getExtension()) === 'php') {
+                    $files[] = $file->getPathname();
+                }
+            }
+        } catch (UnexpectedValueException) {
+            // Keep whatever was collected before the unreadable entry.
+        }
+
+        sort($files);
+
+        return $files;
+    }
+}

--- a/tests/Unit/Detectors/ApproachesDetectorTest.php
+++ b/tests/Unit/Detectors/ApproachesDetectorTest.php
@@ -1,0 +1,310 @@
+<?php
+
+declare(strict_types=1);
+
+use Laravel\Roster\ApproachResult;
+use Laravel\Roster\Detectors\ApproachesDetector;
+use Laravel\Roster\Enums\Approach;
+use Laravel\Roster\Support\ApproachSet;
+
+function detectApproaches(string $app): ApproachSet
+{
+    return new ApproachSet(ApproachesDetector::detect(
+        dirname(__DIR__, 2).DIRECTORY_SEPARATOR.'fixtures'.DIRECTORY_SEPARATOR.'approaches'.DIRECTORY_SEPARATOR.$app,
+    ));
+}
+
+function writeModel(string $base, string $name, string $property): void
+{
+    touchFile($base.'app/Models/'.$name.'.php');
+    file_put_contents(
+        $base.'app/Models/'.$name.'.php',
+        "<?php\n\nnamespace App\\Models;\n\nclass {$name}\n{\n    protected \${$property} = [];\n}\n",
+    );
+}
+
+it('detects fillable as the dominant mass-assignment style', function (): void {
+    $approaches = detectApproaches('fillable-models-app');
+
+    expect($approaches->uses(Approach::MASS_ASSIGNMENT_FILLABLE))->toBeTrue()
+        ->and($approaches->uses(Approach::MASS_ASSIGNMENT_GUARDED))->toBeFalse();
+
+    /** @var ApproachResult $result */
+    $result = $approaches->all()->get(Approach::MASS_ASSIGNMENT_FILLABLE->value);
+
+    expect($result->matched)->toBe(6)
+        ->and($result->total)->toBe(6)
+        ->and($result->confidence)->toBe(1.0)
+        ->and($result->paths)->toHaveCount(6)
+        ->and($result->paths[0])->toContain('Models');
+});
+
+it('detects guarded as the dominant mass-assignment style', function (): void {
+    $approaches = detectApproaches('guarded-models-app');
+
+    expect($approaches->uses(Approach::MASS_ASSIGNMENT_GUARDED))->toBeTrue()
+        ->and($approaches->uses(Approach::MASS_ASSIGNMENT_FILLABLE))->toBeFalse();
+
+    /** @var ApproachResult $result */
+    $result = $approaches->all()->get(Approach::MASS_ASSIGNMENT_GUARDED->value);
+
+    expect($result->matched)->toBe(5)
+        ->and($result->total)->toBe(5);
+});
+
+it('stays silent when models are split between fillable and guarded', function (): void {
+    $approaches = detectApproaches('mixed-models-app');
+
+    expect($approaches->uses(Approach::MASS_ASSIGNMENT_FILLABLE))->toBeFalse()
+        ->and($approaches->uses(Approach::MASS_ASSIGNMENT_GUARDED))->toBeFalse()
+        ->and($approaches->all())->toBeEmpty();
+});
+
+it('detects screaming snake enum case naming with one vote per case', function (): void {
+    $approaches = detectApproaches('screaming-enums-app');
+
+    expect($approaches->uses(Approach::ENUM_CASE_SCREAMING_SNAKE))->toBeTrue();
+
+    /** @var ApproachResult $result */
+    $result = $approaches->all()->get(Approach::ENUM_CASE_SCREAMING_SNAKE->value);
+
+    expect($result->matched)->toBe(5)
+        ->and($result->total)->toBe(5)
+        ->and($result->paths)->toHaveCount(2);
+});
+
+it('does not count switch case labels as enum cases', function (): void {
+    $approaches = detectApproaches('enum-switch-app');
+
+    expect($approaches->uses(Approach::ENUM_CASE_SCREAMING_SNAKE))->toBeTrue();
+
+    /** @var ApproachResult $result */
+    $result = $approaches->all()->get(Approach::ENUM_CASE_SCREAMING_SNAKE->value);
+
+    // The `case Active:` inside the switch must not vote — 5 enum cases, not 6.
+    expect($result->matched)->toBe(5)
+        ->and($result->total)->toBe(5);
+});
+
+it('detects pascal enum case naming', function (): void {
+    $approaches = detectApproaches('pascal-enums-app');
+
+    expect($approaches->uses(Approach::ENUM_CASE_PASCAL))->toBeTrue()
+        ->and($approaches->uses(Approach::ENUM_CASE_SCREAMING_SNAKE))->toBeFalse();
+
+    /** @var ApproachResult $result */
+    $result = $approaches->all()->get(Approach::ENUM_CASE_PASCAL->value);
+
+    expect($result->matched)->toBe(5)
+        ->and($result->total)->toBe(5);
+});
+
+it('detects camel enum case naming', function (): void {
+    $approaches = detectApproaches('camel-enums-app');
+
+    expect($approaches->uses(Approach::ENUM_CASE_CAMEL))->toBeTrue();
+
+    /** @var ApproachResult $result */
+    $result = $approaches->all()->get(Approach::ENUM_CASE_CAMEL->value);
+
+    expect($result->matched)->toBe(5)
+        ->and($result->total)->toBe(5);
+});
+
+it('counts enum cases declared after a method with string interpolation', function (): void {
+    $approaches = detectApproaches('interpolated-enums-app');
+
+    expect($approaches->uses(Approach::ENUM_CASE_SCREAMING_SNAKE))->toBeTrue();
+
+    /** @var ApproachResult $result */
+    $result = $approaches->all()->get(Approach::ENUM_CASE_SCREAMING_SNAKE->value);
+
+    // The `{$this->value}` interpolation must not skew brace depth — all
+    // 5 cases vote, including the 3 declared after the label() method.
+    expect($result->matched)->toBe(5)
+        ->and($result->total)->toBe(5);
+});
+
+it('detects pipe-delimited validation rule syntax', function (): void {
+    $approaches = detectApproaches('pipe-validation-app');
+
+    expect($approaches->uses(Approach::VALIDATION_PIPE_SYNTAX))->toBeTrue()
+        ->and($approaches->uses(Approach::VALIDATION_ARRAY_SYNTAX))->toBeFalse();
+
+    /** @var ApproachResult $result */
+    $result = $approaches->all()->get(Approach::VALIDATION_PIPE_SYNTAX->value);
+
+    expect($result->matched)->toBe(5)
+        ->and($result->total)->toBe(5)
+        ->and($result->paths[0])->toContain('Requests');
+});
+
+it('detects array validation rule syntax', function (): void {
+    $approaches = detectApproaches('array-validation-app');
+
+    expect($approaches->uses(Approach::VALIDATION_ARRAY_SYNTAX))->toBeTrue()
+        ->and($approaches->uses(Approach::VALIDATION_PIPE_SYNTAX))->toBeFalse();
+
+    /** @var ApproachResult $result */
+    $result = $approaches->all()->get(Approach::VALIDATION_ARRAY_SYNTAX->value);
+
+    expect($result->matched)->toBe(5)
+        ->and($result->total)->toBe(5);
+});
+
+it('detects the #[Scope] attribute style with one vote per scope', function (): void {
+    $approaches = detectApproaches('attribute-scopes-app');
+
+    expect($approaches->uses(Approach::QUERY_SCOPE_ATTRIBUTE))->toBeTrue()
+        ->and($approaches->uses(Approach::QUERY_SCOPE_METHOD))->toBeFalse();
+
+    /** @var ApproachResult $result */
+    $result = $approaches->all()->get(Approach::QUERY_SCOPE_ATTRIBUTE->value);
+
+    expect($result->matched)->toBe(5)
+        ->and($result->total)->toBe(5);
+});
+
+it('detects the scopeXxx() naming style', function (): void {
+    $approaches = detectApproaches('naming-scopes-app');
+
+    expect($approaches->uses(Approach::QUERY_SCOPE_METHOD))->toBeTrue()
+        ->and($approaches->uses(Approach::QUERY_SCOPE_ATTRIBUTE))->toBeFalse();
+});
+
+it('samples Models directories anywhere beneath a PSR-4 root', function (): void {
+    $approaches = detectApproaches('nested-models-app');
+
+    expect($approaches->uses(Approach::MASS_ASSIGNMENT_FILLABLE))->toBeTrue();
+
+    /** @var ApproachResult $result */
+    $result = $approaches->all()->get(Approach::MASS_ASSIGNMENT_FILLABLE->value);
+
+    expect($result->matched)->toBe(5)
+        ->and($result->paths[0])->toContain('src/Domain/Orders/Models');
+});
+
+it('stays silent when there are too few votes', function (): void {
+    expect(detectApproaches('carbon-app')->all())->toBeEmpty();
+});
+
+it('rejects a 4/5 majority via the Wilson lower bound', function (): void {
+    $base = tempBase();
+
+    foreach (['Alpha', 'Bravo', 'Charlie', 'Delta'] as $name) {
+        writeModel($base, $name, 'fillable');
+    }
+
+    writeModel($base, 'Hotel', 'guarded');
+
+    $approaches = new ApproachSet(ApproachesDetector::detect($base));
+
+    expect($approaches->uses(Approach::MASS_ASSIGNMENT_FILLABLE))->toBeFalse()
+        ->and($approaches->uses(Approach::MASS_ASSIGNMENT_GUARDED))->toBeFalse();
+
+    cleanup($base);
+});
+
+it('accepts a 90/100 majority via the Wilson lower bound', function (): void {
+    $base = tempBase();
+
+    for ($i = 1; $i <= 90; $i++) {
+        writeModel($base, 'Fillable'.$i, 'fillable');
+    }
+
+    for ($i = 1; $i <= 10; $i++) {
+        writeModel($base, 'Guarded'.$i, 'guarded');
+    }
+
+    $approaches = new ApproachSet(ApproachesDetector::detect($base));
+
+    expect($approaches->uses(Approach::MASS_ASSIGNMENT_FILLABLE))->toBeTrue();
+
+    /** @var ApproachResult $result */
+    $result = $approaches->all()->get(Approach::MASS_ASSIGNMENT_FILLABLE->value);
+
+    expect($result->matched)->toBe(90)
+        ->and($result->total)->toBe(100)
+        ->and($result->confidence)->toBe(0.9)
+        ->and($result->paths)->toHaveCount(100);
+
+    cleanup($base);
+});
+
+it('skips models declaring both fillable and guarded', function (): void {
+    $base = tempBase();
+
+    foreach (['Alpha', 'Bravo', 'Charlie', 'Delta', 'Hotel'] as $name) {
+        writeModel($base, $name, 'fillable');
+    }
+
+    touchFile($base.'app/Models/Both.php');
+    file_put_contents(
+        $base.'app/Models/Both.php',
+        "<?php\n\nnamespace App\\Models;\n\nclass Both\n{\n    protected \$fillable = [];\n\n    protected \$guarded = [];\n}\n",
+    );
+
+    $approaches = new ApproachSet(ApproachesDetector::detect($base));
+
+    /** @var ApproachResult $result */
+    $result = $approaches->all()->get(Approach::MASS_ASSIGNMENT_FILLABLE->value);
+
+    expect($result->matched)->toBe(5)
+        ->and($result->total)->toBe(5)
+        ->and($result->paths)->toHaveCount(5);
+
+    cleanup($base);
+});
+
+it('never lets vendor or node_modules code vote', function (): void {
+    $base = tempBase();
+
+    // A PSR-4 mapping that resolves to the project root pulls everything in.
+    file_put_contents($base.'composer.json', json_encode([
+        'autoload' => ['psr-4' => ['App\\' => '.']],
+    ]));
+
+    foreach (['vendor/acme/pkg/src', 'node_modules/pkg'] as $dir) {
+        for ($i = 1; $i <= 5; $i++) {
+            touchFile($base.$dir.'/Models/Dep'.$i.'.php');
+            file_put_contents(
+                $base.$dir.'/Models/Dep'.$i.'.php',
+                "<?php\n\nclass Dep{$i}\n{\n    protected \$guarded = [];\n}\n",
+            );
+        }
+    }
+
+    $approaches = new ApproachSet(ApproachesDetector::detect($base));
+
+    expect($approaches->all())->toBeEmpty();
+
+    cleanup($base);
+});
+
+it('accepts an array of approaches with any-of semantics', function (): void {
+    $approaches = detectApproaches('fillable-models-app');
+
+    expect($approaches->uses([Approach::MASS_ASSIGNMENT_FILLABLE, Approach::MASS_ASSIGNMENT_GUARDED]))->toBeTrue()
+        ->and($approaches->uses([Approach::MASS_ASSIGNMENT_GUARDED, Approach::ENUM_CASE_CAMEL]))->toBeFalse();
+});
+
+it('dedupes files reachable through overlapping source roots', function (): void {
+    $base = tempBase();
+
+    file_put_contents($base.'composer.json', json_encode([
+        'autoload' => ['psr-4' => ['App\\' => 'app/', 'App\\Models\\' => 'app/Models/']],
+    ]));
+
+    foreach (['Alpha', 'Bravo', 'Charlie', 'Delta', 'Hotel'] as $name) {
+        writeModel($base, $name, 'fillable');
+    }
+
+    $approaches = new ApproachSet(ApproachesDetector::detect($base));
+
+    /** @var ApproachResult $result */
+    $result = $approaches->all()->get(Approach::MASS_ASSIGNMENT_FILLABLE->value);
+
+    expect($result->total)->toBe(5);
+
+    cleanup($base);
+});

--- a/tests/Unit/ProjectApproachesTest.php
+++ b/tests/Unit/ProjectApproachesTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+use Laravel\Roster\Enums\Approach;
+use Laravel\Roster\Project;
+
+function approachesFixturePath(string $app): string
+{
+    return dirname(__DIR__).DIRECTORY_SEPARATOR.'fixtures'.DIRECTORY_SEPARATOR.'approaches'.DIRECTORY_SEPARATOR.$app;
+}
+
+it('exposes approaches from a full project scan', function (): void {
+    $project = Project::scan(approachesFixturePath('fillable-models-app'));
+
+    expect($project->approaches()->uses(Approach::MASS_ASSIGNMENT_FILLABLE))->toBeTrue()
+        ->and($project->approaches()->uses(Approach::MASS_ASSIGNMENT_GUARDED))->toBeFalse();
+});
+
+it('keeps the array payload cheap by omitting approaches', function (): void {
+    $payload = Project::scan(approachesFixturePath('fillable-models-app'))->toArray();
+
+    expect($payload)->not->toHaveKey('approaches');
+});
+
+it('drops approaches on serialization and recomputes them lazily', function (): void {
+    $project = Project::scan(approachesFixturePath('fillable-models-app'));
+
+    // Warm the lazy detection, then round-trip like the scan cache would.
+    $project->approaches();
+
+    $restored = unserialize(serialize($project));
+
+    expect($project->__serialize())->not->toHaveKey('approaches')
+        ->and($restored)->toBeInstanceOf(Project::class)
+        ->and($restored->approaches()->uses(Approach::MASS_ASSIGNMENT_FILLABLE))->toBeTrue();
+});

--- a/tests/Unit/ScanCommandTest.php
+++ b/tests/Unit/ScanCommandTest.php
@@ -35,6 +35,22 @@ it('outputs empty JSON for empty directory', function (): void {
     rmdir($emptyDir);
 });
 
+it('includes approaches only when requested', function (): void {
+    $path = __DIR__.'/../fixtures/approaches/fillable-models-app';
+
+    Artisan::call('roster:scan', ['directory' => $path, '--no-system' => true]);
+    $decoded = json_decode(Artisan::output(), true);
+
+    expect($decoded)->not->toHaveKey('approaches');
+
+    Artisan::call('roster:scan', ['directory' => $path, '--approaches' => true, '--no-system' => true]);
+    $decoded = json_decode(Artisan::output(), true);
+
+    expect($decoded)->toHaveKey('approaches');
+    expect($decoded['approaches'])->toHaveKey('mass-assignment-fillable');
+    expect($decoded['approaches']['mass-assignment-fillable']['matched'])->toBe(6);
+});
+
 it('returns failure for non-existent directory', function (): void {
     $exitCode = Artisan::call('roster:scan', ['directory' => '/non/existent/directory']);
     expect($exitCode)->toBe(1);

--- a/tests/Unit/Support/ApproachSetTest.php
+++ b/tests/Unit/Support/ApproachSetTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Collection;
+use Laravel\Roster\ApproachResult;
+use Laravel\Roster\Enums\Approach;
+use Laravel\Roster\Support\ApproachSet;
+
+it('reports membership and exposes results keyed by approach value', function (): void {
+    $result = new ApproachResult(
+        approach: Approach::MASS_ASSIGNMENT_FILLABLE,
+        confidence: 0.9,
+        matched: 9,
+        total: 10,
+        paths: ['/app/Models/User.php'],
+    );
+
+    $set = new ApproachSet([$result]);
+
+    expect($set->uses(Approach::MASS_ASSIGNMENT_FILLABLE))->toBeTrue()
+        ->and($set->uses(Approach::MASS_ASSIGNMENT_GUARDED))->toBeFalse()
+        ->and($set->all())->toBeInstanceOf(Collection::class)
+        ->and($set->all()->get(Approach::MASS_ASSIGNMENT_FILLABLE->value))->toBe($result);
+});
+
+it('is empty when nothing was detected', function (): void {
+    $set = new ApproachSet([]);
+
+    expect($set->all())->toBeEmpty()
+        ->and($set->uses(Approach::ENUM_CASE_SCREAMING_SNAKE))->toBeFalse();
+});
+
+it('serializes results to an array shape', function (): void {
+    $result = new ApproachResult(
+        approach: Approach::VALIDATION_PIPE_SYNTAX,
+        confidence: 1.0,
+        matched: 5,
+        total: 5,
+        paths: ['/app/Http/Requests/StorePostRequest.php'],
+    );
+
+    expect($result->toArray())->toBe([
+        'approach' => 'validation-pipe-syntax',
+        'confidence' => 1.0,
+        'matched' => 5,
+        'total' => 5,
+        'paths' => ['/app/Http/Requests/StorePostRequest.php'],
+    ]);
+});

--- a/tests/fixtures/approaches/array-validation-app/app/Http/Requests/StoreCommentRequest.php
+++ b/tests/fixtures/approaches/array-validation-app/app/Http/Requests/StoreCommentRequest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreCommentRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'email' => ['required', 'email'],
+        ];
+    }
+}

--- a/tests/fixtures/approaches/array-validation-app/app/Http/Requests/StorePostRequest.php
+++ b/tests/fixtures/approaches/array-validation-app/app/Http/Requests/StorePostRequest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StorePostRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'email' => ['required', 'email'],
+        ];
+    }
+}

--- a/tests/fixtures/approaches/array-validation-app/app/Http/Requests/StoreUserRequest.php
+++ b/tests/fixtures/approaches/array-validation-app/app/Http/Requests/StoreUserRequest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreUserRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'email' => ['required', 'email'],
+        ];
+    }
+}

--- a/tests/fixtures/approaches/array-validation-app/app/Http/Requests/UpdatePostRequest.php
+++ b/tests/fixtures/approaches/array-validation-app/app/Http/Requests/UpdatePostRequest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdatePostRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'email' => ['required', 'email'],
+        ];
+    }
+}

--- a/tests/fixtures/approaches/array-validation-app/app/Http/Requests/UpdateUserRequest.php
+++ b/tests/fixtures/approaches/array-validation-app/app/Http/Requests/UpdateUserRequest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateUserRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'email' => ['required', 'email'],
+        ];
+    }
+}

--- a/tests/fixtures/approaches/array-validation-app/composer.json
+++ b/tests/fixtures/approaches/array-validation-app/composer.json
@@ -1,0 +1,4 @@
+{
+    "name": "acme/array-validation-app",
+    "autoload": { "psr-4": { "App\\": "app/" } }
+}

--- a/tests/fixtures/approaches/attribute-scopes-app/app/Models/Comment.php
+++ b/tests/fixtures/approaches/attribute-scopes-app/app/Models/Comment.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Attributes\Scope;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+
+class Comment extends Model
+{
+    #[Scope]
+    protected function approved(Builder $query): Builder
+    {
+        return $query->where('approved', true);
+    }
+}

--- a/tests/fixtures/approaches/attribute-scopes-app/app/Models/Invoice.php
+++ b/tests/fixtures/approaches/attribute-scopes-app/app/Models/Invoice.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Attributes\Scope;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+
+class Invoice extends Model
+{
+    #[Scope]
+    protected function unpaid(Builder $query): Builder
+    {
+        return $query->whereNull('paid_at');
+    }
+}

--- a/tests/fixtures/approaches/attribute-scopes-app/app/Models/Order.php
+++ b/tests/fixtures/approaches/attribute-scopes-app/app/Models/Order.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Attributes\Scope;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+
+class Order extends Model
+{
+    #[Scope]
+    protected function pending(Builder $query): Builder
+    {
+        return $query->where('status', 'pending');
+    }
+}

--- a/tests/fixtures/approaches/attribute-scopes-app/app/Models/Post.php
+++ b/tests/fixtures/approaches/attribute-scopes-app/app/Models/Post.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Attributes\Scope;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+
+class Post extends Model
+{
+    #[Scope]
+    protected function published(Builder $query): Builder
+    {
+        return $query->whereNotNull('published_at');
+    }
+}

--- a/tests/fixtures/approaches/attribute-scopes-app/app/Models/User.php
+++ b/tests/fixtures/approaches/attribute-scopes-app/app/Models/User.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Attributes\Scope;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+
+class User extends Model
+{
+    #[Scope]
+    protected function active(Builder $query): Builder
+    {
+        return $query->where('active', true);
+    }
+}

--- a/tests/fixtures/approaches/attribute-scopes-app/composer.json
+++ b/tests/fixtures/approaches/attribute-scopes-app/composer.json
@@ -1,0 +1,8 @@
+{
+    "name": "acme/attribute-scopes-app",
+    "autoload": {
+        "psr-4": {
+            "App\\": "app/"
+        }
+    }
+}

--- a/tests/fixtures/approaches/camel-enums-app/app/Enums/OrderStatus.php
+++ b/tests/fixtures/approaches/camel-enums-app/app/Enums/OrderStatus.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Enums;
+
+enum OrderStatus: string
+{
+    case pending = 'pending';
+    case paid = 'paid';
+    case shipped = 'shipped';
+}

--- a/tests/fixtures/approaches/camel-enums-app/app/Enums/PaymentStatus.php
+++ b/tests/fixtures/approaches/camel-enums-app/app/Enums/PaymentStatus.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Enums;
+
+enum PaymentStatus: string
+{
+    case authorized = 'authorized';
+    case captured = 'captured';
+}

--- a/tests/fixtures/approaches/camel-enums-app/composer.json
+++ b/tests/fixtures/approaches/camel-enums-app/composer.json
@@ -1,0 +1,4 @@
+{
+    "name": "acme/camel-enums-app",
+    "autoload": { "psr-4": { "App\\": "app/" } }
+}

--- a/tests/fixtures/approaches/carbon-app/app/Providers/AppServiceProvider.php
+++ b/tests/fixtures/approaches/carbon-app/app/Providers/AppServiceProvider.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Providers;
+
+use Carbon\CarbonImmutable;
+use Illuminate\Support\Facades\Date;
+use Illuminate\Support\ServiceProvider;
+
+class AppServiceProvider extends ServiceProvider
+{
+    public function boot(): void
+    {
+        Date::use(CarbonImmutable::class);
+    }
+}

--- a/tests/fixtures/approaches/enum-switch-app/app/Enums/Level.php
+++ b/tests/fixtures/approaches/enum-switch-app/app/Enums/Level.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Enums;
+
+enum Level: string
+{
+    case LOW = 'low';
+    case MEDIUM = 'medium';
+    case HIGH = 'high';
+    case URGENT = 'urgent';
+    case CRITICAL = 'critical';
+
+    public function describe(string $flag): string
+    {
+        switch ($flag) {
+            case Active:
+                return 'active';
+
+            default:
+                return 'inactive';
+        }
+    }
+}

--- a/tests/fixtures/approaches/enum-switch-app/composer.json
+++ b/tests/fixtures/approaches/enum-switch-app/composer.json
@@ -1,0 +1,4 @@
+{
+    "name": "acme/enum-switch-app",
+    "autoload": { "psr-4": { "App\\": "app/" } }
+}

--- a/tests/fixtures/approaches/fillable-models-app/app/Models/Category.php
+++ b/tests/fixtures/approaches/fillable-models-app/app/Models/Category.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Category extends Model
+{
+    protected $fillable = ['name', 'slug'];
+}

--- a/tests/fixtures/approaches/fillable-models-app/app/Models/Comment.php
+++ b/tests/fixtures/approaches/fillable-models-app/app/Models/Comment.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Comment extends Model
+{
+    protected $fillable = ['body', 'post_id'];
+}

--- a/tests/fixtures/approaches/fillable-models-app/app/Models/Post.php
+++ b/tests/fixtures/approaches/fillable-models-app/app/Models/Post.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Post extends Model
+{
+    protected $fillable = ['title', 'body'];
+}

--- a/tests/fixtures/approaches/fillable-models-app/app/Models/Tag.php
+++ b/tests/fixtures/approaches/fillable-models-app/app/Models/Tag.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Tag extends Model
+{
+    protected $fillable = ['label'];
+}

--- a/tests/fixtures/approaches/fillable-models-app/app/Models/Team.php
+++ b/tests/fixtures/approaches/fillable-models-app/app/Models/Team.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Team extends Model
+{
+    protected $fillable = ['name', 'owner_id'];
+}

--- a/tests/fixtures/approaches/fillable-models-app/app/Models/User.php
+++ b/tests/fixtures/approaches/fillable-models-app/app/Models/User.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class User extends Model
+{
+    protected $fillable = ['name', 'email'];
+}

--- a/tests/fixtures/approaches/fillable-models-app/composer.json
+++ b/tests/fixtures/approaches/fillable-models-app/composer.json
@@ -1,0 +1,8 @@
+{
+    "name": "acme/fillable-models-app",
+    "autoload": {
+        "psr-4": {
+            "App\\": "app/"
+        }
+    }
+}

--- a/tests/fixtures/approaches/guarded-models-app/app/Models/Account.php
+++ b/tests/fixtures/approaches/guarded-models-app/app/Models/Account.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Account extends Model
+{
+    protected $guarded = ['id'];
+}

--- a/tests/fixtures/approaches/guarded-models-app/app/Models/Invoice.php
+++ b/tests/fixtures/approaches/guarded-models-app/app/Models/Invoice.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Invoice extends Model
+{
+    protected $guarded = ['id'];
+}

--- a/tests/fixtures/approaches/guarded-models-app/app/Models/Ledger.php
+++ b/tests/fixtures/approaches/guarded-models-app/app/Models/Ledger.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Ledger extends Model
+{
+    protected $guarded = ['id'];
+}

--- a/tests/fixtures/approaches/guarded-models-app/app/Models/Payment.php
+++ b/tests/fixtures/approaches/guarded-models-app/app/Models/Payment.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Payment extends Model
+{
+    protected $guarded = ['id'];
+}

--- a/tests/fixtures/approaches/guarded-models-app/app/Models/Transfer.php
+++ b/tests/fixtures/approaches/guarded-models-app/app/Models/Transfer.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Transfer extends Model
+{
+    protected $guarded = ['id'];
+}

--- a/tests/fixtures/approaches/guarded-models-app/composer.json
+++ b/tests/fixtures/approaches/guarded-models-app/composer.json
@@ -1,0 +1,8 @@
+{
+    "name": "acme/guarded-models-app",
+    "autoload": {
+        "psr-4": {
+            "App\\": "app/"
+        }
+    }
+}

--- a/tests/fixtures/approaches/interpolated-enums-app/app/Enums/Status.php
+++ b/tests/fixtures/approaches/interpolated-enums-app/app/Enums/Status.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Enums;
+
+enum Status: string
+{
+    case ACTIVE = 'active';
+    case PAUSED = 'paused';
+
+    public function label(): string
+    {
+        return "State: {$this->value}";
+    }
+
+    case ARCHIVED = 'archived';
+    case DELETED = 'deleted';
+    case PENDING_REVIEW = 'pending';
+}

--- a/tests/fixtures/approaches/interpolated-enums-app/composer.json
+++ b/tests/fixtures/approaches/interpolated-enums-app/composer.json
@@ -1,0 +1,4 @@
+{
+    "name": "acme/interpolated-enums-app",
+    "autoload": { "psr-4": { "App\\": "app/" } }
+}

--- a/tests/fixtures/approaches/mixed-models-app/app/Models/Alpha.php
+++ b/tests/fixtures/approaches/mixed-models-app/app/Models/Alpha.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Alpha extends Model
+{
+    protected $fillable = ['name'];
+}

--- a/tests/fixtures/approaches/mixed-models-app/app/Models/Bravo.php
+++ b/tests/fixtures/approaches/mixed-models-app/app/Models/Bravo.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Bravo extends Model
+{
+    protected $fillable = ['name'];
+}

--- a/tests/fixtures/approaches/mixed-models-app/app/Models/Charlie.php
+++ b/tests/fixtures/approaches/mixed-models-app/app/Models/Charlie.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Charlie extends Model
+{
+    protected $fillable = ['name'];
+}

--- a/tests/fixtures/approaches/mixed-models-app/app/Models/Delta.php
+++ b/tests/fixtures/approaches/mixed-models-app/app/Models/Delta.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Delta extends Model
+{
+    protected $guarded = ['id'];
+}

--- a/tests/fixtures/approaches/mixed-models-app/app/Models/Foxtrot.php
+++ b/tests/fixtures/approaches/mixed-models-app/app/Models/Foxtrot.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Foxtrot extends Model
+{
+    protected $guarded = ['id'];
+}

--- a/tests/fixtures/approaches/mixed-models-app/composer.json
+++ b/tests/fixtures/approaches/mixed-models-app/composer.json
@@ -1,0 +1,8 @@
+{
+    "name": "acme/mixed-models-app",
+    "autoload": {
+        "psr-4": {
+            "App\\": "app/"
+        }
+    }
+}

--- a/tests/fixtures/approaches/naming-scopes-app/app/Models/Comment.php
+++ b/tests/fixtures/approaches/naming-scopes-app/app/Models/Comment.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+
+class Comment extends Model
+{
+    public function scopeApproved(Builder $query): Builder
+    {
+        return $query->where('approved', true);
+    }
+}

--- a/tests/fixtures/approaches/naming-scopes-app/app/Models/Invoice.php
+++ b/tests/fixtures/approaches/naming-scopes-app/app/Models/Invoice.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+
+class Invoice extends Model
+{
+    public function scopeUnpaid(Builder $query): Builder
+    {
+        return $query->whereNull('paid_at');
+    }
+}

--- a/tests/fixtures/approaches/naming-scopes-app/app/Models/Order.php
+++ b/tests/fixtures/approaches/naming-scopes-app/app/Models/Order.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+
+class Order extends Model
+{
+    public function scopePending(Builder $query): Builder
+    {
+        return $query->where('status', 'pending');
+    }
+}

--- a/tests/fixtures/approaches/naming-scopes-app/app/Models/Post.php
+++ b/tests/fixtures/approaches/naming-scopes-app/app/Models/Post.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+
+class Post extends Model
+{
+    public function scopePublished(Builder $query): Builder
+    {
+        return $query->whereNotNull('published_at');
+    }
+}

--- a/tests/fixtures/approaches/naming-scopes-app/app/Models/User.php
+++ b/tests/fixtures/approaches/naming-scopes-app/app/Models/User.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+
+class User extends Model
+{
+    public function scopeActive(Builder $query): Builder
+    {
+        return $query->where('active', true);
+    }
+}

--- a/tests/fixtures/approaches/naming-scopes-app/composer.json
+++ b/tests/fixtures/approaches/naming-scopes-app/composer.json
@@ -1,0 +1,8 @@
+{
+    "name": "acme/naming-scopes-app",
+    "autoload": {
+        "psr-4": {
+            "App\\": "app/"
+        }
+    }
+}

--- a/tests/fixtures/approaches/nested-models-app/composer.json
+++ b/tests/fixtures/approaches/nested-models-app/composer.json
@@ -1,0 +1,8 @@
+{
+    "name": "acme/nested-models-app",
+    "autoload": {
+        "psr-4": {
+            "App\\Domain\\": "src/Domain/"
+        }
+    }
+}

--- a/tests/fixtures/approaches/nested-models-app/src/Domain/Orders/Models/Invoice.php
+++ b/tests/fixtures/approaches/nested-models-app/src/Domain/Orders/Models/Invoice.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Domain\Orders\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Invoice extends Model
+{
+    protected $fillable = ['reference', 'amount'];
+}

--- a/tests/fixtures/approaches/nested-models-app/src/Domain/Orders/Models/Order.php
+++ b/tests/fixtures/approaches/nested-models-app/src/Domain/Orders/Models/Order.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Domain\Orders\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Order extends Model
+{
+    protected $fillable = ['reference', 'amount'];
+}

--- a/tests/fixtures/approaches/nested-models-app/src/Domain/Orders/Models/Payment.php
+++ b/tests/fixtures/approaches/nested-models-app/src/Domain/Orders/Models/Payment.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Domain\Orders\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Payment extends Model
+{
+    protected $fillable = ['reference', 'amount'];
+}

--- a/tests/fixtures/approaches/nested-models-app/src/Domain/Orders/Models/Refund.php
+++ b/tests/fixtures/approaches/nested-models-app/src/Domain/Orders/Models/Refund.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Domain\Orders\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Refund extends Model
+{
+    protected $fillable = ['reference', 'amount'];
+}

--- a/tests/fixtures/approaches/nested-models-app/src/Domain/Orders/Models/Shipment.php
+++ b/tests/fixtures/approaches/nested-models-app/src/Domain/Orders/Models/Shipment.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Domain\Orders\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Shipment extends Model
+{
+    protected $fillable = ['reference', 'amount'];
+}

--- a/tests/fixtures/approaches/pascal-enums-app/app/Enums/OrderStatus.php
+++ b/tests/fixtures/approaches/pascal-enums-app/app/Enums/OrderStatus.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Enums;
+
+enum OrderStatus: string
+{
+    case Pending = 'pending';
+    case Paid = 'paid';
+    case Shipped = 'shipped';
+}

--- a/tests/fixtures/approaches/pascal-enums-app/app/Enums/PaymentStatus.php
+++ b/tests/fixtures/approaches/pascal-enums-app/app/Enums/PaymentStatus.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Enums;
+
+enum PaymentStatus: string
+{
+    case Authorized = 'authorized';
+    case Captured = 'captured';
+}

--- a/tests/fixtures/approaches/pascal-enums-app/composer.json
+++ b/tests/fixtures/approaches/pascal-enums-app/composer.json
@@ -1,0 +1,4 @@
+{
+    "name": "acme/pascal-enums-app",
+    "autoload": { "psr-4": { "App\\": "app/" } }
+}

--- a/tests/fixtures/approaches/pipe-validation-app/app/Http/Requests/StoreCommentRequest.php
+++ b/tests/fixtures/approaches/pipe-validation-app/app/Http/Requests/StoreCommentRequest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreCommentRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return [
+            'name' => 'required|string|max:255',
+            'email' => 'required|email',
+        ];
+    }
+}

--- a/tests/fixtures/approaches/pipe-validation-app/app/Http/Requests/StorePostRequest.php
+++ b/tests/fixtures/approaches/pipe-validation-app/app/Http/Requests/StorePostRequest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StorePostRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return [
+            'name' => 'required|string|max:255',
+            'email' => 'required|email',
+        ];
+    }
+}

--- a/tests/fixtures/approaches/pipe-validation-app/app/Http/Requests/StoreUserRequest.php
+++ b/tests/fixtures/approaches/pipe-validation-app/app/Http/Requests/StoreUserRequest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreUserRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return [
+            'name' => 'required|string|max:255',
+            'email' => 'required|email',
+        ];
+    }
+}

--- a/tests/fixtures/approaches/pipe-validation-app/app/Http/Requests/UpdatePostRequest.php
+++ b/tests/fixtures/approaches/pipe-validation-app/app/Http/Requests/UpdatePostRequest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdatePostRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return [
+            'name' => 'required|string|max:255',
+            'email' => 'required|email',
+        ];
+    }
+}

--- a/tests/fixtures/approaches/pipe-validation-app/app/Http/Requests/UpdateUserRequest.php
+++ b/tests/fixtures/approaches/pipe-validation-app/app/Http/Requests/UpdateUserRequest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateUserRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return [
+            'name' => 'required|string|max:255',
+            'email' => 'required|email',
+        ];
+    }
+}

--- a/tests/fixtures/approaches/pipe-validation-app/composer.json
+++ b/tests/fixtures/approaches/pipe-validation-app/composer.json
@@ -1,0 +1,4 @@
+{
+    "name": "acme/pipe-validation-app",
+    "autoload": { "psr-4": { "App\\": "app/" } }
+}

--- a/tests/fixtures/approaches/screaming-enums-app/app/Enums/OrderStatus.php
+++ b/tests/fixtures/approaches/screaming-enums-app/app/Enums/OrderStatus.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Enums;
+
+enum OrderStatus: string
+{
+    case PENDING = 'pending';
+    case PAID = 'paid';
+    case SHIPPED = 'shipped';
+}

--- a/tests/fixtures/approaches/screaming-enums-app/app/Enums/PaymentStatus.php
+++ b/tests/fixtures/approaches/screaming-enums-app/app/Enums/PaymentStatus.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Enums;
+
+enum PaymentStatus: string
+{
+    case AUTHORIZED = 'authorized';
+    case CAPTURED = 'captured';
+}

--- a/tests/fixtures/approaches/screaming-enums-app/composer.json
+++ b/tests/fixtures/approaches/screaming-enums-app/composer.json
@@ -1,0 +1,4 @@
+{
+    "name": "acme/screaming-enums-app",
+    "autoload": { "psr-4": { "App\\": "app/" } }
+}


### PR DESCRIPTION
Adds `Project::approaches()` — detection of the stylistic conventions the application's **own source code** has adopted: `$fillable` vs `$guarded`, enum case casing, pipe vs array validation syntax, and `#[Scope]` vs `scopeXxx()` query scopes.

- Files are discovered from `composer.json` PSR-4 roots unioned with `app/`, with `vendor/`, `node_modules/`, and hidden directories pruned.
- A winner is only reported with enough evidence: ≥ 5 votes and a Wilson score lower bound (95% CI) ≥ 0.5 — a 4/5 majority is rejected, 90/100 passes, a split stays silent.
- Computed lazily and never persisted with the cached scan (source changes without lockfile changes); `roster:scan --approaches` opts into including it.

Most of the line count is test fixture apps.
---

### Review stack (splits #48)

| | PR | Layer |
|---|----|-------|
| 1 | #63 | Adopt Pint and Rector with granular composer test scripts |
| 2 | #64 | Add basePath detectors for agents, JS package managers, and approaches |
| 3 | #58 | Redesign detection API around ecosystems and detectors |
| 4 | #59 | Split detection into Project and System surfaces |
| 5 | #60 | Drop the alias registry in favor of raw package names |
| 6 | #61 | Split Editor from Agent and scan transitive JS dependencies |
| 7 | #62 | Add source convention detection via Project::approaches **← this PR** |

Each PR is based on the one above it — review bottom-up, merge bottom-up. The test suite is green at every layer, and the top of the stack is byte-identical to #48's branch. #48 remains as a draft umbrella showing the combined diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)