### PR TITLE
Add basePath detectors for agents, JS package managers, and approaches

### DIFF
--- a/src/Contracts/ScopedCollection.php
+++ b/src/Contracts/ScopedCollection.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Roster\Contracts;
+
+interface ScopedCollection
+{
+    /**
+     * @param  mixed  $value  single case or array of cases
+     */
+    public function uses(mixed $value): bool;
+
+    /**
+     * @return array<int, mixed>
+     */
+    public function all(): array;
+}

--- a/src/Contracts/ScopedDetection.php
+++ b/src/Contracts/ScopedDetection.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Roster\Contracts;
+
+interface ScopedDetection
+{
+    public function configured(): ScopedCollection;
+
+    public function installed(): ScopedCollection;
+}

--- a/src/Detectors/AgentsDetection.php
+++ b/src/Detectors/AgentsDetection.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Roster\Detectors;
+
+use Laravel\Roster\Contracts\ScopedDetection;
+use Laravel\Roster\Enums\Agent;
+use Laravel\Roster\Support\EnumSet;
+
+class AgentsDetection implements ScopedDetection
+{
+    /** @var EnumSet<Agent> */
+    protected EnumSet $configured;
+
+    /** @var EnumSet<Agent> */
+    protected EnumSet $installed;
+
+    /**
+     * @param  array<int, Agent>  $configured
+     * @param  array<int, Agent>  $installed
+     */
+    public function __construct(array $configured, array $installed)
+    {
+        $this->configured = new EnumSet($configured);
+        $this->installed = new EnumSet($installed);
+    }
+
+    /**
+     * @return EnumSet<Agent>
+     */
+    public function configured(): EnumSet
+    {
+        return $this->configured;
+    }
+
+    /**
+     * @return EnumSet<Agent>
+     */
+    public function installed(): EnumSet
+    {
+        return $this->installed;
+    }
+}

--- a/src/Detectors/AgentsDetector.php
+++ b/src/Detectors/AgentsDetector.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Laravel\Roster\Detectors;
+
+use Laravel\Roster\Enums\Agent;
+use Laravel\Roster\Support\SystemProbe;
+
+class AgentsDetector
+{
+    /**
+     * Project-level markers. The presence of any marker for an agent counts as configured.
+     *
+     * @var array<string, list<string>>
+     */
+    private const PROJECT_MARKERS = [
+        Agent::CLAUDE_CODE->value => ['.claude', 'CLAUDE.md', '.claude.json'],
+        Agent::CURSOR->value => ['.cursor', '.cursorrules'],
+        Agent::CODEX->value => ['.codex', 'AGENTS.md'],
+        Agent::COPILOT->value => ['.github/copilot-instructions.md'],
+        Agent::GEMINI->value => ['.gemini', 'GEMINI.md'],
+        Agent::JUNIE->value => ['.junie'],
+        Agent::KIRO->value => ['.kiro'],
+        Agent::OPENCODE->value => ['.opencode', 'opencode.json'],
+        Agent::AMP->value => ['.amp', 'amp.json'],
+        Agent::REPLIT->value => ['.replit', 'replit.nix'],
+        Agent::DEVIN->value => ['.devin'],
+        Agent::V0->value => ['.v0'],
+        Agent::AUGMENT->value => ['.augment'],
+        Agent::ANTIGRAVITY->value => ['.antigravity'],
+        Agent::WINDSURF->value => ['.windsurf', '.windsurfrules'],
+        Agent::PHPSTORM->value => ['.idea'],
+        Agent::VSCODE->value => ['.vscode'],
+    ];
+
+    /**
+     * System binaries that indicate an agent is installed.
+     *
+     * @var array<string, list<string>>
+     */
+    private const SYSTEM_BINARIES = [
+        Agent::CLAUDE_CODE->value => ['claude'],
+        Agent::CURSOR->value => ['cursor'],
+        Agent::CODEX->value => ['codex'],
+        Agent::COPILOT->value => ['gh-copilot'],
+        Agent::GEMINI->value => ['gemini'],
+        Agent::JUNIE->value => ['junie'],
+        Agent::KIRO->value => ['kiro'],
+        Agent::OPENCODE->value => ['opencode'],
+        Agent::AMP->value => ['amp'],
+        Agent::WINDSURF->value => ['windsurf'],
+        Agent::PHPSTORM->value => ['phpstorm'],
+        Agent::VSCODE->value => ['code'],
+    ];
+
+    public function __construct(
+        protected string $basePath,
+        protected bool $detectSystem = true,
+    ) {}
+
+    public function detect(): AgentsDetection
+    {
+        return new AgentsDetection(
+            $this->detectFromProjectMarkers(),
+            $this->detectSystem ? $this->detectFromSystemBinaries() : [],
+        );
+    }
+
+    /**
+     * @return list<Agent>
+     */
+    private function detectFromProjectMarkers(): array
+    {
+        $configured = [];
+
+        foreach (self::PROJECT_MARKERS as $agentValue => $markers) {
+            foreach ($markers as $marker) {
+                if (SystemProbe::pathExists($this->basePath.str_replace('/', DIRECTORY_SEPARATOR, $marker))) {
+                    $configured[] = Agent::from($agentValue);
+
+                    break;
+                }
+            }
+        }
+
+        return $configured;
+    }
+
+    /**
+     * @return list<Agent>
+     */
+    private function detectFromSystemBinaries(): array
+    {
+        $installed = [];
+
+        foreach (self::SYSTEM_BINARIES as $agentValue => $binaries) {
+            foreach ($binaries as $binary) {
+                if (SystemProbe::commandExists($binary)) {
+                    $installed[] = Agent::from($agentValue);
+
+                    break;
+                }
+            }
+        }
+
+        return $installed;
+    }
+}

--- a/src/Detectors/ApproachDetector.php
+++ b/src/Detectors/ApproachDetector.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Laravel\Roster\Detectors;
+
+use Laravel\Roster\Enums\Approach;
+use Laravel\Roster\Support\EnumSet;
+
+class ApproachDetector
+{
+    public function __construct(protected string $basePath) {}
+
+    /**
+     * @return EnumSet<Approach>
+     */
+    public function detect(): EnumSet
+    {
+        /** @var array<int, Approach> $found */
+        $found = [];
+
+        if (is_dir($this->basePath.'app'.DIRECTORY_SEPARATOR.'Actions')) {
+            $found[] = Approach::ACTION;
+        }
+
+        if (is_dir($this->basePath.'app'.DIRECTORY_SEPARATOR.'Domains')) {
+            $found[] = Approach::DDD;
+        }
+
+        if (is_dir($this->basePath.'modules')
+            || is_dir($this->basePath.'Modules')
+            || is_dir($this->basePath.'app-modules')) {
+            $found[] = Approach::MODULAR;
+        }
+
+        return new EnumSet($found);
+    }
+}

--- a/src/Detectors/PackageManagersDetection.php
+++ b/src/Detectors/PackageManagersDetection.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Roster\Detectors;
+
+use Laravel\Roster\Contracts\ScopedDetection;
+use Laravel\Roster\Enums\JsPackageManager;
+use Laravel\Roster\Support\EnumSet;
+
+class PackageManagersDetection implements ScopedDetection
+{
+    /** @var EnumSet<JsPackageManager> */
+    protected EnumSet $configured;
+
+    /** @var EnumSet<JsPackageManager> */
+    protected EnumSet $installed;
+
+    /**
+     * @param  array<int, JsPackageManager>  $configured
+     * @param  array<int, JsPackageManager>  $installed
+     */
+    public function __construct(array $configured, array $installed)
+    {
+        $this->configured = new EnumSet($configured);
+        $this->installed = new EnumSet($installed);
+    }
+
+    /**
+     * @return EnumSet<JsPackageManager>
+     */
+    public function configured(): EnumSet
+    {
+        return $this->configured;
+    }
+
+    /**
+     * @return EnumSet<JsPackageManager>
+     */
+    public function installed(): EnumSet
+    {
+        return $this->installed;
+    }
+}

--- a/src/Detectors/PackageManagersDetector.php
+++ b/src/Detectors/PackageManagersDetector.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Roster\Detectors;
+
+use Laravel\Roster\Enums\JsPackageManager;
+use Laravel\Roster\Support\SystemProbe;
+
+class PackageManagersDetector
+{
+    public function __construct(
+        protected string $basePath,
+        protected bool $detectSystem = true,
+    ) {}
+
+    public function detect(?JsPackageManager $committed): PackageManagersDetection
+    {
+        $configured = $committed instanceof JsPackageManager ? [$committed] : [];
+        $installed = [];
+
+        if ($this->detectSystem) {
+            foreach (JsPackageManager::cases() as $manager) {
+                if (SystemProbe::commandExists($manager->binary())) {
+                    $installed[] = $manager;
+                }
+            }
+        }
+
+        return new PackageManagersDetection($configured, $installed);
+    }
+}

--- a/src/Enums/Agent.php
+++ b/src/Enums/Agent.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Roster\Enums;
+
+enum Agent: string
+{
+    case CLAUDE_CODE = 'claude-code';
+    case CURSOR = 'cursor';
+    case CODEX = 'codex';
+    case COPILOT = 'copilot';
+    case GEMINI = 'gemini';
+    case JUNIE = 'junie';
+    case KIRO = 'kiro';
+    case OPENCODE = 'opencode';
+    case AMP = 'amp';
+    case REPLIT = 'replit';
+    case DEVIN = 'devin';
+    case V0 = 'v0';
+    case AUGMENT = 'augment';
+    case ANTIGRAVITY = 'antigravity';
+    case WINDSURF = 'windsurf';
+    case PHPSTORM = 'phpstorm';
+    case VSCODE = 'vscode';
+}

--- a/src/Enums/Approach.php
+++ b/src/Enums/Approach.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Roster\Enums;
+
+enum Approach: string
+{
+    case ACTION = 'action';
+    case DDD = 'ddd';
+    case MODULAR = 'modular';
+}

--- a/src/Enums/JsPackageManager.php
+++ b/src/Enums/JsPackageManager.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Laravel\Roster\Enums;
+
+enum JsPackageManager: string
+{
+    case NPM = 'npm';
+    case PNPM = 'pnpm';
+    case YARN = 'yarn';
+    case BUN = 'bun';
+
+    public function lockFile(): string
+    {
+        return match ($this) {
+            self::NPM => 'package-lock.json',
+            self::PNPM => 'pnpm-lock.yaml',
+            self::YARN => 'yarn.lock',
+            self::BUN => 'bun.lock',
+        };
+    }
+
+    public function binary(): string
+    {
+        return $this->value;
+    }
+}

--- a/src/Support/EnumSet.php
+++ b/src/Support/EnumSet.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Roster\Support;
+
+use BackedEnum;
+use Illuminate\Support\Arr;
+use Laravel\Roster\Contracts\ScopedCollection;
+
+/**
+ * @template T of BackedEnum
+ */
+class EnumSet implements ScopedCollection
+{
+    /**
+     * @param  array<int, T>  $cases
+     */
+    public function __construct(protected array $cases) {}
+
+    /**
+     * @param  T|array<int, T>  $value
+     */
+    public function uses(mixed $value): bool
+    {
+        foreach (Arr::wrap($value) as $needle) {
+            if (in_array($needle, $this->cases, true)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param  T  $value
+     */
+    public function is(BackedEnum $value): bool
+    {
+        return in_array($value, $this->cases, true);
+    }
+
+    /**
+     * @return array<int, T>
+     */
+    public function all(): array
+    {
+        return $this->cases;
+    }
+
+    /**
+     * @return array<int, string|int>
+     */
+    public function values(): array
+    {
+        return array_map(fn (BackedEnum $c): int|string => $c->value, $this->cases);
+    }
+}

--- a/src/Support/SystemProbe.php
+++ b/src/Support/SystemProbe.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Laravel\Roster\Support;
+
+class SystemProbe
+{
+    /** @var array<string, bool> */
+    protected static array $cache = [];
+
+    public static function commandExists(string $binary): bool
+    {
+        if (array_key_exists($binary, self::$cache)) {
+            return self::$cache[$binary];
+        }
+
+        if (! function_exists('proc_open')) {
+            return self::$cache[$binary] = false;
+        }
+
+        $isWindows = DIRECTORY_SEPARATOR === '\\';
+        $cmd = $isWindows ? 'where '.escapeshellarg($binary) : 'command -v '.escapeshellarg($binary);
+
+        $descriptors = [
+            0 => ['pipe', 'r'],
+            1 => ['pipe', 'w'],
+            2 => ['pipe', 'w'],
+        ];
+
+        $proc = @proc_open($cmd, $descriptors, $pipes);
+        if (! is_resource($proc)) {
+            return self::$cache[$binary] = false;
+        }
+
+        foreach ($pipes as $pipe) {
+            if (is_resource($pipe)) {
+                fclose($pipe);
+            }
+        }
+
+        $exit = proc_close($proc);
+
+        return self::$cache[$binary] = ($exit === 0);
+    }
+
+    public static function pathExists(string $path): bool
+    {
+        return $path !== '' && file_exists($path);
+    }
+
+    public static function resetCache(): void
+    {
+        self::$cache = [];
+    }
+}

--- a/tests/Unit/Detectors/AgentsDetectorTest.php
+++ b/tests/Unit/Detectors/AgentsDetectorTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+use Laravel\Roster\Detectors\AgentsDetector;
+use Laravel\Roster\Enums\Agent;
+
+it('detects configured agents from filesystem markers', function (): void {
+    $base = sys_get_temp_dir().DIRECTORY_SEPARATOR.'roster_agents_'.uniqid().DIRECTORY_SEPARATOR;
+    mkdir($base);
+    mkdir($base.'.claude');
+    mkdir($base.'.cursor');
+
+    $detection = (new AgentsDetector($base, detectSystem: false))->detect();
+    expect($detection->configured()->is(Agent::CLAUDE_CODE))->toBeTrue();
+    expect($detection->configured()->is(Agent::CURSOR))->toBeTrue();
+    expect($detection->configured()->is(Agent::PHPSTORM))->toBeFalse();
+
+    rmdir($base.'.claude');
+    rmdir($base.'.cursor');
+    rmdir($base);
+});
+
+it('skips installed probes when detectSystem is false', function (): void {
+    $base = sys_get_temp_dir().DIRECTORY_SEPARATOR.'roster_agents_nosys_'.uniqid().DIRECTORY_SEPARATOR;
+    mkdir($base);
+
+    $detection = (new AgentsDetector($base, detectSystem: false))->detect();
+    expect($detection->installed()->all())->toBe([]);
+
+    rmdir($base);
+});

--- a/tests/Unit/Detectors/ApproachDetectorTest.php
+++ b/tests/Unit/Detectors/ApproachDetectorTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+use Laravel\Roster\Detectors\ApproachDetector;
+use Laravel\Roster\Enums\Approach;
+
+it('detects action approach from app/Actions directory', function (): void {
+    $base = sys_get_temp_dir().DIRECTORY_SEPARATOR.'roster_approach_'.uniqid().DIRECTORY_SEPARATOR;
+    mkdir($base.'app'.DIRECTORY_SEPARATOR.'Actions', 0777, true);
+
+    $detection = (new ApproachDetector($base))->detect();
+    expect($detection->uses(Approach::ACTION))->toBeTrue();
+
+    rmdir($base.'app'.DIRECTORY_SEPARATOR.'Actions');
+    rmdir($base.'app');
+    rmdir($base);
+});
+
+it('detects modular approach from modules / Modules / app-modules', function (): void {
+    foreach (['modules', 'Modules', 'app-modules'] as $dir) {
+        $base = sys_get_temp_dir().DIRECTORY_SEPARATOR.'roster_modular_'.uniqid().DIRECTORY_SEPARATOR;
+        mkdir($base.$dir, 0777, true);
+
+        $detection = (new ApproachDetector($base))->detect();
+        expect($detection->uses(Approach::MODULAR))->toBeTrue();
+
+        rmdir($base.$dir);
+        rmdir($base);
+    }
+});
+
+it('returns empty detection on a bare directory', function (): void {
+    $base = sys_get_temp_dir().DIRECTORY_SEPARATOR.'roster_empty_'.uniqid().DIRECTORY_SEPARATOR;
+    mkdir($base);
+
+    $detection = (new ApproachDetector($base))->detect();
+    expect($detection->all())->toBe([]);
+
+    rmdir($base);
+});


### PR DESCRIPTION
Purely **additive** — no existing file is touched, so nothing can regress:

- `AgentsDetector`, `PackageManagersDetector`, and `ApproachDetector`: filesystem-marker and PATH-binary detection needing only a `$basePath`.
- Support classes they report through: `EnumSet`, `SystemProbe`, the `ScopedDetection`/`ScopedCollection` contracts, and the `AgentsDetection`/`PackageManagersDetection` wrappers.
- New `Agent`, `JsPackageManager`, and `Approach` enums. These deliberately **coexist** with the current `Ides`, `NodePackageManager`, and `Approaches` enums — the old ones are removed in the next PR when the core adopts the new detectors.

Files are verbatim from the final design; tests cover marker detection and the `detectSystem: false` escape hatch.
---

### Review stack (splits #48)

| | PR | Layer |
|---|----|-------|
| 1 | #63 | Adopt Pint and Rector with granular composer test scripts |
| 2 | #64 | Add basePath detectors for agents, JS package managers, and approaches **← this PR** |
| 3 | #58 | Redesign detection API around ecosystems and detectors |
| 4 | #59 | Split detection into Project and System surfaces |
| 5 | #60 | Drop the alias registry in favor of raw package names |
| 6 | #61 | Split Editor from Agent and scan transitive JS dependencies |
| 7 | #62 | Add source convention detection via Project::approaches |

Each PR is based on the one above it — review bottom-up, merge bottom-up. The test suite is green at every layer, and the top of the stack is byte-identical to #48's branch. #48 remains as a draft umbrella showing the combined diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)