### PR TITLE
Expose the project's minimum PHP version

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 - [Installation](#installation)
 - [Basic Usage](#basic-usage)
 - [Detecting Packages](#detecting-packages)
+    - [Minimum PHP Version](#minimum-php-version)
     - [Version Constraints](#version-constraints)
     - [Checking Multiple Packages](#checking-multiple-packages)
     - [Retrieving Packages](#retrieving-packages)
@@ -79,6 +80,14 @@ The `uses` method returns `true` when **any** of the given packages is present, 
 ```php
 $project->php()->uses('pestphp/pest');
 $project->js()->uses('@inertiajs/react');
+```
+
+### Minimum PHP Version
+
+The PHP ecosystem reports the minimum major and minor version allowed by the root `composer.json` requirement. When the requirement is missing or has no usable lower bound, Roster falls back to the running PHP version:
+
+```php
+$project->minimumPhpVersion(); // "8.3"
 ```
 
 ### Version Constraints

--- a/src/Facades/Project.php
+++ b/src/Facades/Project.php
@@ -12,6 +12,7 @@ use Laravel\Roster\ProjectManager;
  * @method static \Laravel\Roster\ProjectScan fresh(?string $basePath = null)
  * @method static \Laravel\Roster\ProjectScan instance()
  * @method static \Laravel\Roster\Ecosystems\Ecosystem php()
+ * @method static string minimumPhpVersion()
  * @method static \Laravel\Roster\Ecosystems\JsEcosystem js()
  * @method static \Laravel\Roster\Support\EnumSet<\Laravel\Roster\Enums\Stack> stacks()
  * @method static \Laravel\Roster\Support\EnumSet<\Laravel\Roster\Enums\BrowserTestFramework> browserTestFrameworks()

--- a/src/ProjectManager.php
+++ b/src/ProjectManager.php
@@ -59,6 +59,11 @@ class ProjectManager
         return $this->instance()->php();
     }
 
+    public function minimumPhpVersion(): string
+    {
+        return $this->instance()->minimumPhpVersion();
+    }
+
     public function js(): JsEcosystem
     {
         return $this->instance()->js();
@@ -153,7 +158,7 @@ class ProjectManager
 
     private function cacheKey(string $basePath): string
     {
-        return 'roster:project:v3:'.md5(
+        return 'roster:project:v4:'.md5(
             $basePath.'|'.$this->lockfileHash($basePath).'|'.$this->markerHash($basePath)
         );
     }

--- a/src/ProjectScan.php
+++ b/src/ProjectScan.php
@@ -44,6 +44,7 @@ class ProjectScan
         protected EnumSet $frontends,
         protected EnumSet $agents,
         protected EnumSet $editors,
+        protected ?string $minimumPhpVersion = null,
     ) {
         //
     }
@@ -51,6 +52,11 @@ class ProjectScan
     public function php(): Ecosystem
     {
         return $this->php;
+    }
+
+    public function minimumPhpVersion(): string
+    {
+        return $this->minimumPhpVersion ?? PHP_MAJOR_VERSION.'.'.PHP_MINOR_VERSION;
     }
 
     public function js(): JsEcosystem
@@ -99,7 +105,8 @@ class ProjectScan
     {
         $basePath = self::normalizeBasePath($basePath);
 
-        $phpPackages = (new ComposerLock($basePath))->scan();
+        $composer = new ComposerLock($basePath);
+        $phpPackages = $composer->scan();
 
         $jsLockfile = new JsLockfile($basePath);
         $jsPackages = $jsLockfile->scan();
@@ -116,6 +123,7 @@ class ProjectScan
             new EnumSet(FrontendDetector::detect($js)),
             new EnumSet(AgentsDetector::detect($basePath)),
             new EnumSet(EditorsDetector::detect($basePath)),
+            $composer->minimumPhpVersion(),
         );
     }
 
@@ -147,6 +155,7 @@ class ProjectScan
     {
         return [
             'php' => array_map(fn (Package $package): array => $package->toArray(), $this->php->packages()->all()),
+            'minimumPhpVersion' => $this->minimumPhpVersion(),
             'js' => array_map(fn (Package $package): array => $package->toArray(), $this->js->packages()->all()),
             'stacks' => $this->stacks->values(),
             'browserTestFrameworks' => $this->browserTestFrameworks->values(),
@@ -191,6 +200,7 @@ class ProjectScan
      *     frontends: EnumSet<Frontend>,
      *     agents: EnumSet<Agent>,
      *     editors: EnumSet<Editor>,
+     *     minimumPhpVersion: ?string,
      * }  $properties
      */
     public function __unserialize(array $properties): void

--- a/src/Scanners/ComposerLock.php
+++ b/src/Scanners/ComposerLock.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Laravel\Roster\Scanners;
 
+use Composer\Semver\VersionParser;
 use Laravel\Roster\Enums\PackageSource;
 use Laravel\Roster\PackageCollection;
+use UnexpectedValueException;
 
 class ComposerLock extends PackageScanner
 {
@@ -27,6 +29,33 @@ class ComposerLock extends PackageScanner
         $this->processDependencies($this->versions($json['packages-dev'] ?? null), $packages, true, authoritative: true);
 
         return $packages;
+    }
+
+    public function minimumPhpVersion(): ?string
+    {
+        $require = $this->manifest()['require'] ?? null;
+
+        if (! is_array($require) || ! is_string($require['php'] ?? null)) {
+            return null;
+        }
+
+        try {
+            $lowerBound = (new VersionParser)
+                ->parseConstraints($require['php'])
+                ->getLowerBound();
+        } catch (UnexpectedValueException) {
+            return null;
+        }
+
+        if ($lowerBound->isZero()) {
+            return null;
+        }
+
+        if (preg_match('/^(\d+)\.(\d+)/', $lowerBound->getVersion(), $matches) !== 1) {
+            return null;
+        }
+
+        return $matches[1].'.'.$matches[2];
     }
 
     protected function source(): PackageSource

--- a/tests/Unit/ProjectScanTest.php
+++ b/tests/Unit/ProjectScanTest.php
@@ -23,3 +23,27 @@ it('falls back to the working directory when base_path() has no bound applicatio
         Container::setInstance($original);
     }
 });
+
+it('reports the minimum PHP version supported by the project', function (): void {
+    $base = tempBase();
+
+    file_put_contents($base.'composer.json', json_encode([
+        'require' => ['php' => '^8.2'],
+    ]));
+
+    $project = ProjectScan::scan($base);
+
+    expect($project->minimumPhpVersion())->toBe('8.2')
+        ->and($project->toArray()['minimumPhpVersion'])->toBe('8.2');
+
+    cleanup($base);
+});
+
+it('falls back to the running PHP version without a usable project requirement', function (): void {
+    $base = tempBase();
+
+    expect(ProjectScan::scan($base)->minimumPhpVersion())
+        ->toBe(PHP_MAJOR_VERSION.'.'.PHP_MINOR_VERSION);
+
+    cleanup($base);
+});

--- a/tests/Unit/Scanners/ComposerLockTest.php
+++ b/tests/Unit/Scanners/ComposerLockTest.php
@@ -156,3 +156,42 @@ it('leaves the constraint blank for transitive packages and normalizes the versi
 
     cleanup($base);
 });
+
+it('finds the minimum PHP minor version from the root requirement', function (string $constraint, string $version): void {
+    $base = tempBase();
+
+    file_put_contents($base.'composer.json', json_encode([
+        'require' => ['php' => $constraint],
+    ]));
+
+    expect((new ComposerLock($base))->minimumPhpVersion())->toBe($version);
+
+    cleanup($base);
+})->with([
+    'caret' => ['^8.3', '8.3'],
+    'tilde with patch' => ['~8.2.5', '8.2'],
+    'bounded range' => ['>=8.1 <8.5', '8.1'],
+    'disjunction' => ['^8.2 || ^8.4', '8.2'],
+    'exclusive lower bound' => ['>8.3.0', '8.3'],
+    'wildcard minor' => ['8.4.*', '8.4'],
+]);
+
+it('does not infer a minimum PHP version from an unusable requirement', function (?string $constraint): void {
+    $base = tempBase();
+
+    if ($constraint !== null) {
+        file_put_contents($base.'composer.json', json_encode([
+            'require' => ['php' => $constraint],
+        ]));
+    }
+
+    expect((new ComposerLock($base))->minimumPhpVersion())->toBeNull();
+
+    cleanup($base);
+})->with([
+    'missing manifest' => [null],
+    'unbounded wildcard' => ['*'],
+    'upper bound only' => ['<8.4'],
+    'development branch' => ['dev-main'],
+    'invalid constraint' => ['not-a-version'],
+]);


### PR DESCRIPTION
Closes #31.

A project can run on PHP 8.5 while still promising PHP 8.2 compatibility in its root `composer.json`. Tools consuming Roster should be able to use that project requirement instead of assuming syntax from the local interpreter is safe.

This adds `minimumPhpVersion()` to the project scan and manager surfaces. The value comes from the Composer constraint's real lower bound and is exposed in scan JSON as `minimumPhpVersion`. Constraints without a usable numeric lower bound, as well as missing or malformed requirements, fall back to the running PHP major/minor.

The existing `php()` ecosystem and `ProjectScan` constructor remain compatible; the new constructor state is optional. The cache namespace is bumped so scans serialized before this field existed are not reused after upgrading.

Validation:

- `composer test:unit` — 187 tests, 485 assertions
- `vendor/bin/pint --test`
- `vendor/bin/rector process --dry-run` on the changed PHP and test files
- `vendor/bin/phpstan analyse --no-progress --memory-limit=512M`
- `vendor/bin/testbench roster:scan tests/fixtures/fog` — reports `minimumPhpVersion` as `8.3` for `^8.3`

The regression coverage includes caret, tilde, bounded, disjunctive, exclusive, and wildcard-minor constraints, plus missing, unbounded, branch, upper-bound-only, and invalid requirements.
